### PR TITLE
Drop `rvm` stanza

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache:
   bundler: true
   directories:
   - tmp/cache/assets/test
-rvm:
-- 2.3.0
 addons:
   postgresql: 9.4
 before_script:


### PR DESCRIPTION
When the `rvm` stanza is unspecified, travis will fallback on the
`.ruby-version` specified Ruby. Depending on this behaviour means we
can drop the redundant version information here, since we specify it
canonically in the `.ruby-version` file.