### PR TITLE
Add simple import for google-based data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,3 +370,6 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
+
+BUNDLED WITH
+   1.11.2

--- a/app/models/where_did_you_hear.rb
+++ b/app/models/where_did_you_hear.rb
@@ -1,0 +1,2 @@
+class WhereDidYouHear < ActiveRecord::Base
+end

--- a/db/migrate/20160428162511_create_where_did_you_hears.rb
+++ b/db/migrate/20160428162511_create_where_did_you_hears.rb
@@ -1,0 +1,13 @@
+class CreateWhereDidYouHears < ActiveRecord::Migration
+  def change
+    create_table :where_did_you_hears do |t|
+      t.datetime :given_at, null: false
+      t.string :delivery_partner, null: false
+      t.string :where, null: false, default: ''
+      t.string :pension_provider, null: false, default: ''
+      t.string :location, null: false, default: ''
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160421121524) do
+ActiveRecord::Schema.define(version: 20160428162511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,16 @@ ActiveRecord::Schema.define(version: 20160421121524) do
     t.boolean  "disabled",                default: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
+  end
+
+  create_table "where_did_you_hears", force: :cascade do |t|
+    t.datetime "given_at",                      null: false
+    t.string   "delivery_partner",              null: false
+    t.string   "where",            default: "", null: false
+    t.string   "pension_provider", default: "", null: false
+    t.string   "location",         default: "", null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
   end
 
 end

--- a/lib/importers.rb
+++ b/lib/importers.rb
@@ -1,0 +1,3 @@
+module Importers
+  autoload :WhereDidYouHearAboutUs, 'importers/where_did_you_hear_about_us'
+end

--- a/lib/importers/where_did_you_hear_about_us.rb
+++ b/lib/importers/where_did_you_hear_about_us.rb
@@ -1,0 +1,5 @@
+module Importers
+  module WhereDidYouHearAboutUs
+    autoload :Google, 'importers/where_did_you_hear_about_us/google'
+  end
+end

--- a/lib/importers/where_did_you_hear_about_us/google.rb
+++ b/lib/importers/where_did_you_hear_about_us/google.rb
@@ -1,0 +1,7 @@
+module Importers
+  module WhereDidYouHearAboutUs
+    module Google
+      autoload :Importer, 'importers/where_did_you_hear_about_us/google/importer'
+    end
+  end
+end

--- a/lib/importers/where_did_you_hear_about_us/google/importer.rb
+++ b/lib/importers/where_did_you_hear_about_us/google/importer.rb
@@ -1,0 +1,39 @@
+require 'csv'
+
+module Importers
+  module WhereDidYouHearAboutUs
+    module Google
+      class Importer
+        def initialize(csv:, delivery_partner:, output: STDOUT)
+          @csv = csv
+          @delivery_partner = delivery_partner
+          @output = output
+        end
+
+        def call
+          ActiveRecord::Base.transaction do
+            CSV.new(@csv).map { |row| create_from(row) }
+          end
+        end
+
+        private
+
+        def create_from(row)
+          @output.puts "Creating #{row.inspect}"
+
+          WhereDidYouHear.create!(
+            given_at: format_date(row[0]),
+            where: row[1].to_s,
+            pension_provider: row[2].to_s,
+            location: row[3].to_s,
+            delivery_partner: @delivery_partner
+          )
+        end
+
+        def format_date(date)
+          DateTime.strptime(date, '%m/%d/%Y %H:%M:%S')
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,4 +1,19 @@
 namespace :import do
+  desc 'Import google forms `where did you hear data`'
+  task google: :environment do
+    require_relative '../importers'
+
+    csv_path = ENV.fetch('CSV')
+    partner  = ENV.fetch('PARTNER')
+
+    Importers::WhereDidYouHearAboutUs::Google::Importer.new(
+      csv: open(csv_path),
+      delivery_partner: partner
+    ).call
+
+    puts 'done!'
+  end
+
   desc 'Import twilio data for the either the specified DATE or yesterday'
   task twilio: :environment do
     date_string = ENV.fetch('DATE', Time.zone.yesterday.to_s)

--- a/spec/features/import_google_where_did_you_hear_data_spec.rb
+++ b/spec/features/import_google_where_did_you_hear_data_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require_relative '../../lib/importers'
+
+RSpec.feature 'Importing google `where did you hear about us` data' do
+  let(:csv) do
+    StringIO.new(
+      <<~CSV
+        1/27/2016 13:26:15,Pension Provider,L&G,Lochaber Citizens Advice Bureau
+      CSV
+    )
+  end
+  let(:entry) { WhereDidYouHear.last }
+
+  scenario 'imports correctly structured data' do
+    Importers::WhereDidYouHearAboutUs::Google::Importer.new(
+      csv: csv,
+      delivery_partner: 'CAS',
+      output: StringIO.new
+    ).call
+
+    expect(entry.given_at).to eq('2016-01-27 13:26:15 UTC')
+
+    expect(entry).to have_attributes(
+      where: 'Pension Provider',
+      pension_provider: 'L&G',
+      location: 'Lochaber Citizens Advice Bureau',
+      delivery_partner: 'CAS'
+    )
+  end
+end


### PR DESCRIPTION
Imports the google forms backed 'where did you hear' data. This is a
one-off task that can be scrapped after the cut-off period for our usage of
google forms for the 'where did you hear' data.

At the moment we just take the data as-is. Some of this appears to be of
'varying' quality. I'm sure we'll need some manual cleanup once complete.

Imports from the provided `CSV` and `PARTNER` environment variables. For
example:
```
$ bundle exec rake import:google CSV=file.csv PARTNER=CAS
```