### PR TITLE
Add 'where did you hear about us?' dashboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 addons:
   postgresql: 9.4
 before_script:
-- "./bin/rake db:setup RAILS_ENV=test"
+  - "./bin/rake db:create db:migrate RAILS_ENV=test"
 deploy:
   provider: heroku
   api_key:

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,11 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'bugsnag'
+gem 'bootstrap-kaminari-views'
 gem 'gds-sso'
 gem 'govuk_admin_template'
 gem 'foreman'
+gem 'kaminari'
 gem 'puma'
 gem 'sidekiq'
 gem 'sinatra', require: nil
@@ -39,6 +41,7 @@ group :test do
 end
 
 group :development, :test do
+  gem 'factory_girl_rails'
   gem 'rspec-rails'
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     backports (3.6.8)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-kaminari-views (0.0.5)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
@@ -97,6 +100,11 @@ GEM
     ethon (0.8.1)
       ffi (>= 1.3.0)
     execjs (2.6.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
@@ -140,6 +148,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.1)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -338,15 +349,18 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-kaminari-views
   bugsnag
   capybara
   cucumber-rails
   database_cleaner
+  factory_girl_rails
   foreman
   gds-sso
   govuk_admin_template
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari
   overcommit
   pg (~> 0.15)
   pry-byebug

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,6 +13,13 @@ class ReportsController < ApplicationController
 
   def where_did_you_hear
     @where_did_you_hears = WhereDidYouHears.new(where_did_you_hear_params)
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        render csv: WhereDidYouHearCsv.new(@where_did_you_hears.results)
+      end
+    end
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,7 +11,19 @@ class ReportsController < ApplicationController
     end
   end
 
+  def where_did_you_hear
+    @where_did_you_hears = WhereDidYouHears.new(where_did_you_hear_params)
+  end
+
   private
+
+  def where_did_you_hear_params
+    {
+      page: params[:page],
+      start_date: params.dig(:where_did_you_hears, :start_date),
+      end_date: params.dig(:where_did_you_hears, :end_date)
+    }
+  end
 
   def form_params
     {

--- a/app/forms/where_did_you_hears.rb
+++ b/app/forms/where_did_you_hears.rb
@@ -9,11 +9,14 @@ class WhereDidYouHears
     @end_date   = normalise_date(end_date, Time.zone.today)
   end
 
-  def paginated_results
+  def results
     WhereDidYouHear
       .where(given_at: date_range)
       .order(given_at: :desc)
-      .page(page)
+  end
+
+  def paginated_results
+    results.page(page)
   end
 
   private

--- a/app/forms/where_did_you_hears.rb
+++ b/app/forms/where_did_you_hears.rb
@@ -1,0 +1,28 @@
+class WhereDidYouHears
+  include ActiveModel::Model
+
+  attr_accessor :start_date, :end_date, :page
+
+  def initialize(page:, start_date:, end_date:)
+    @page       = page
+    @start_date = normalise_date(start_date, 1.month.ago.to_date)
+    @end_date   = normalise_date(end_date, Time.zone.today)
+  end
+
+  def paginated_results
+    WhereDidYouHear
+      .where(given_at: date_range)
+      .order(given_at: :desc)
+      .page(page)
+  end
+
+  private
+
+  def date_range
+    start_date.beginning_of_day..end_date.end_of_day
+  end
+
+  def normalise_date(date, default)
+    date.present? ? Time.zone.parse(date) : default
+  end
+end

--- a/app/services/where_did_you_hear_csv.rb
+++ b/app/services/where_did_you_hear_csv.rb
@@ -1,0 +1,37 @@
+require 'csv'
+
+class WhereDidYouHearCsv
+  ATTRIBUTES = %w(
+    id
+    given_at
+    delivery_partner
+    where
+    pension_provider
+    location
+  ).freeze
+
+  def initialize(records)
+    @records = Array(records)
+  end
+
+  def call
+    CSV.generate do |output|
+      output << ATTRIBUTES
+
+      records.each { |record| output << row(record) }
+    end
+  end
+  alias csv call
+
+  private
+
+  attr_reader :records
+
+  def row(record)
+    record
+      .attributes
+      .slice(*ATTRIBUTES)
+      .values
+      .map(&:to_s)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   <li>
     <%= link_to 'Call volumes', call_volumes_path %>
   </li>
+  <li>
+    <%= link_to 'Where did you hear?', reports_where_did_you_hear_path %>
+  </li>
 <% end %>
 
 <% content_for :body_end do %>

--- a/app/views/reports/where_did_you_hear.html.erb
+++ b/app/views/reports/where_did_you_hear.html.erb
@@ -1,0 +1,51 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>Where did you hear about us?</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <div class="well">
+      <%= form_for @where_did_you_hears, url: reports_where_did_you_hear_path, method: :get, html: { class: 'inline form-inline' } do |f| %>
+        <div class="form-group">
+          <%= f.label :start_date, 'From', class: 'inline' %>
+          <%= f.text_field :start_date, type: :date, class: 'form-control t-start', placeholder: 'dd/mm/yyyy' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :end_date, 'To', class: 'inline' %>
+          <%= f.text_field :end_date, type: :date, class: 'form-control t-end', placeholder: 'dd/mm/yyyy' %>
+        </div>
+        <%= f.submit 'Search', class: 'btn btn-default t-search' %>
+      <% end %>
+    </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= paginate @where_did_you_hears.paginated_results, theme: 'twitter-bootstrap-3' %>
+
+    <table class="table table-striped table-bordered">
+      <thead>
+        <tr class="table-header">
+          <th scope="col">Given At</th>
+          <th scope="col">Where they heard</th>
+          <th scope="col">Partner</th>
+          <th scope="col">Location</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%- @where_did_you_hears.paginated_results.each do |where_did_you_hear| %>
+          <tr class="t-row">
+            <td><%= where_did_you_hear.given_at.to_s(:govuk_date) %></td>
+            <td><%= where_did_you_hear.where %></td>
+            <td><%= where_did_you_hear.delivery_partner %></td>
+            <td><%= where_did_you_hear.location %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= paginate @where_did_you_hears.paginated_results, theme: 'twitter-bootstrap-3' %>
+  </div>
+</div>

--- a/app/views/reports/where_did_you_hear.html.erb
+++ b/app/views/reports/where_did_you_hear.html.erb
@@ -17,6 +17,12 @@
         </div>
         <%= f.submit 'Search', class: 'btn btn-default t-search' %>
       <% end %>
+
+      <%= form_for @where_did_you_hears, url: reports_where_did_you_hear_path(format: :csv), method: :get, html: { class: 'inline form-inline' } do |f| %>
+        <%= f.hidden_field :start_date %>
+        <%= f.hidden_field :end_date %>
+        <%= f.submit 'Export CSV', class: 'btn btn-default t-export' %>
+      <% end %>
     </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
   get 'reports/call_volumes', to: 'reports#call_volumes', as: :call_volumes
+  get 'reports/where_did_you_hear'
 
   root 'reports#call_volumes'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,27 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+WHERE     = ['Pension Provider', 'Citizens Advice', 'My Employer', 'TV Advert'].freeze
+PENSIONS  = ['Hargreaves Lansdown', 'Aeon', 'Standard General', 'TSB'].freeze
+LOCATIONS = %w(Dublin Belfast Reading Essex Slough Somerset Cork).freeze
+PARTNER   = %w(CAS TPAS NICAB CITA).freeze
+
+puts 'Deleting existing `WhereDidYouHear` records'
+WhereDidYouHear.delete_all
+
+puts 'Creating new `WhereDidYouHear` records'
+
+100.times do
+  attributes = {
+    given_at: rand(-10.days..10.days).seconds.ago,
+    location: LOCATIONS.sample,
+    delivery_partner: PARTNER.sample,
+    where: WHERE.sample,
+    pension_provider: PENSIONS.sample
+  }
+
+  attributes.except!(:pension_provider) unless attributes[:where] == 'Pension Provider'
+
+  WhereDidYouHear.create!(attributes)
+  print '.'
+end
+
+puts
+puts 'done!'

--- a/features/pages/where_did_you_hear_about_us_report_page.rb
+++ b/features/pages/where_did_you_hear_about_us_report_page.rb
@@ -6,4 +6,5 @@ class WhereDidYouHearAboutUsReportPage < SitePrism::Page
 
   element :start_date, '.t-start'
   element :end_date, '.t-end'
+  element :export_csv, '.t-export'
 end

--- a/features/pages/where_did_you_hear_about_us_report_page.rb
+++ b/features/pages/where_did_you_hear_about_us_report_page.rb
@@ -1,0 +1,9 @@
+class WhereDidYouHearAboutUsReportPage < SitePrism::Page
+  set_url '/reports/where_did_you_hear{?query*}'
+
+  elements :rows, '.t-row'
+  elements :pages, 'li.page'
+
+  element :start_date, '.t-start'
+  element :end_date, '.t-end'
+end

--- a/features/step_definitions/where_did_you_hear_about_us_report_steps.rb
+++ b/features/step_definitions/where_did_you_hear_about_us_report_steps.rb
@@ -1,0 +1,21 @@
+Given(/^there are existing where did you hear about us records$/) do
+  create_list(:where_did_you_hear, Kaminari.config.default_per_page + 1)
+end
+
+When(/^I visit the where did you hear about us report$/) do
+  @page = WhereDidYouHearAboutUsReportPage.new
+  @page.load
+end
+
+Then(/^I am presented with where did you hear about us records$/) do
+  expect(@page).to have_rows(count: Kaminari.config.default_per_page)
+end
+
+Then(/^I see there are multiple pages$/) do
+  expect(@page).to have_pages
+end
+
+Then(/^the date range is displayed$/) do
+  expect(@page.start_date.value).to be_present
+  expect(@page.end_date.value).to be_present
+end

--- a/features/step_definitions/where_did_you_hear_about_us_report_steps.rb
+++ b/features/step_definitions/where_did_you_hear_about_us_report_steps.rb
@@ -19,3 +19,10 @@ Then(/^the date range is displayed$/) do
   expect(@page.start_date.value).to be_present
   expect(@page.end_date.value).to be_present
 end
+
+Then(/^I am prompted to download the CSV$/) do
+  expect(page.response_headers).to include(
+    'Content-Disposition' => 'attachment; filename=data.csv',
+    'Content-Type'        => 'text/csv'
+  )
+end

--- a/features/support/factory_girl.rb
+++ b/features/support/factory_girl.rb
@@ -1,0 +1,1 @@
+World(FactoryGirl::Syntax::Methods)

--- a/features/where_did_hear_about_us_report.feature
+++ b/features/where_did_hear_about_us_report.feature
@@ -1,0 +1,12 @@
+Feature: Where did you hear about us?
+  As a Pension Wise data analyst
+  I want to know how people hear about us
+  So that I can understand whether demand for the service has changed
+
+  Scenario: Viewing where did you hear about us records
+    Given I am logged in as a Pension Wise data analyst
+    And there are existing where did you hear about us records
+    When I visit the where did you hear about us report
+    Then I am presented with where did you hear about us records
+    And I see there are multiple pages
+    And the date range is displayed

--- a/features/where_did_hear_about_us_report.feature
+++ b/features/where_did_hear_about_us_report.feature
@@ -10,3 +10,10 @@ Feature: Where did you hear about us?
     Then I am presented with where did you hear about us records
     And I see there are multiple pages
     And the date range is displayed
+
+  Scenario: Viewing where did you hear about us records
+    Given I am logged in as a Pension Wise data analyst
+    And there are existing where did you hear about us records
+    When I visit the where did you hear about us report
+    And I export the results to CSV
+    Then I am prompted to download the CSV

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :where_did_you_hear do
+    given_at { Time.zone.now }
+    delivery_partner { %w(TPAS NICAB CAS TP).sample }
+    where 'Pension Provider'
+    pension_provider 'Hargreaves Lansdown'
+    location 'Belfast'
+  end
+end

--- a/spec/forms/where_did_you_hears_spec.rb
+++ b/spec/forms/where_did_you_hears_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe WhereDidYouHears do
+  subject { described_class.new(page: nil, start_date: nil, end_date: nil) }
+
+  context 'when initializing' do
+    it 'defaults the start and end dates' do
+      expect(subject.start_date).to eq(1.month.ago.to_date)
+      expect(subject.end_date).to eq(Time.zone.today)
+    end
+  end
+
+  describe '#paginated_results' do
+    let(:page_size_plus_one) { Kaminari.config.default_per_page + 1 }
+
+    it 'returns results within the provided date range' do
+      present = create(:where_did_you_hear, given_at: Time.zone.today)
+      create(:where_did_you_hear, given_at: 1.year.ago)
+
+      expect(subject.paginated_results).to match_array(present)
+    end
+
+    it 'is paginated' do
+      create_list(:where_did_you_hear, page_size_plus_one)
+
+      expect(subject.paginated_results.size).to eq(Kaminari.config.default_per_page)
+    end
+  end
+end

--- a/spec/services/where_did_you_hear_csv_spec.rb
+++ b/spec/services/where_did_you_hear_csv_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe WhereDidYouHearCsv do
+  let(:record) { build_stubbed(:where_did_you_hear) }
+  let(:separator) { ',' }
+
+  subject { described_class.new(record).call.lines }
+
+  describe '#csv' do
+    it 'generates headings' do
+      expect(subject.first.chomp.split(separator)).to match_array(
+        %w(
+          id
+          given_at
+          delivery_partner
+          where
+          pension_provider
+          location
+        )
+      )
+    end
+
+    it 'generates correctly mapped rows' do
+      expect(subject.last.chomp.split(separator)).to match_array(
+        [
+          record.to_param,
+          record.given_at.to_s,
+          record.delivery_partner,
+          record.where,
+          record.pension_provider,
+          record.location
+        ]
+      )
+    end
+  end
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
Adds a simple dashboard for querying these particular records. At the moment
this is by date range only, but could reasonably be extended to cover the
delivery partners or other criteria.

The duplication in the forms and CSV generators could do with some form of
abstraction soon, if we keep repeating them.

![screen shot 2016-05-05 at 12 10 57](https://cloud.githubusercontent.com/assets/41963/15042346/e8b803a6-12ba-11e6-9f00-7380bd22bbc7.png)
