### PR TITLE
Abstract CSV generation

### DIFF
--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'csv'
+
+class CsvGenerator
+  def initialize(record_or_records)
+    @records = Array(record_or_records)
+  end
+
+  def call
+    CSV.generate do |output|
+      output << attributes
+
+      @records.each { |record| output << row(record) }
+    end
+  end
+  alias csv call
+
+  def attributes
+    raise NotImplementedError
+  end
+
+  private
+
+  def row(record)
+    record
+      .attributes
+      .slice(*attributes)
+      .map { |key, value| format(key, value) }
+  end
+
+  def format(key, value)
+    formatter = "#{key}_formatter"
+
+    respond_to?(formatter) ? public_send(formatter, value) : value
+  end
+end

--- a/app/services/daily_call_volume_csv.rb
+++ b/app/services/daily_call_volume_csv.rb
@@ -1,35 +1,6 @@
 # frozen_string_literal: true
-require 'csv'
-
-class DailyCallVolumeCsv
-  ATTRIBUTES = %w(
-    date
-    twilio
-    tp
-  ).freeze
-
-  def initialize(daily_call_volumes)
-    @daily_call_volumes = Array(daily_call_volumes)
-  end
-
-  def call
-    CSV.generate do |output|
-      output << ATTRIBUTES
-
-      daily_call_volumes.each { |daily_call_volume| output << row(daily_call_volume) }
-    end
-  end
-  alias csv call
-
-  private
-
-  attr_reader :daily_call_volumes
-
-  def row(daily_call_volume)
-    daily_call_volume
-      .attributes
-      .slice(*ATTRIBUTES)
-      .values
-      .map(&:to_s)
+class DailyCallVolumeCsv < CsvGenerator
+  def attributes
+    %w(date twilio tp).freeze
   end
 end

--- a/app/services/where_did_you_hear_csv.rb
+++ b/app/services/where_did_you_hear_csv.rb
@@ -1,39 +1,15 @@
-require 'csv'
-
-class WhereDidYouHearCsv
-  ATTRIBUTES = %w(
-    id
-    given_at
-    delivery_partner
-    where_raw
-    where_code
-    where
-    pension_provider
-    location
-  ).freeze
-
-  def initialize(records)
-    @records = Array(records)
-  end
-
-  def call
-    CSV.generate do |output|
-      output << ATTRIBUTES
-
-      records.each { |record| output << row(record) }
-    end
-  end
-  alias csv call
-
-  private
-
-  attr_reader :records
-
-  def row(record)
-    record
-      .attributes
-      .slice(*ATTRIBUTES)
-      .values
-      .map(&:to_s)
+# frozen_string_literal: true
+class WhereDidYouHearCsv < CsvGenerator
+  def attributes
+    %w(
+      id
+      given_at
+      delivery_partner
+      where_raw
+      where_code
+      where
+      pension_provider
+      location
+    ).freeze
   end
 end


### PR DESCRIPTION
Moves the common CSV generation behaviour into a newly abstracted
`CsvGenerator`. You can control formatting of specific attributes by
overriding `attribute_formatter` where `attribute` is the name of the
attribute that needs custom formatting.