### PR TITLE
Renamed `where*` columns

### DIFF
--- a/app/models/where_did_you_hear.rb
+++ b/app/models/where_did_you_hear.rb
@@ -2,7 +2,7 @@ class WhereDidYouHear < ActiveRecord::Base
   before_validation :lookup_mappings
 
   def lookup_mappings
-    self.where = CodeLookup.for(value: where_code)
+    self.heard_from       = CodeLookup.for(value: heard_from_code)
     self.pension_provider = CodeLookup.for(value: pension_provider_code)
   end
 end

--- a/app/services/where_did_you_hear_csv.rb
+++ b/app/services/where_did_you_hear_csv.rb
@@ -5,9 +5,9 @@ class WhereDidYouHearCsv < CsvGenerator
       id
       given_at
       delivery_partner
-      where_raw
-      where_code
-      where
+      heard_from_raw
+      heard_from_code
+      heard_from
       pension_provider
       location
     ).freeze

--- a/app/views/reports/where_did_you_hear.html.erb
+++ b/app/views/reports/where_did_you_hear.html.erb
@@ -45,8 +45,8 @@
         <%- @where_did_you_hears.paginated_results.each do |where_did_you_hear| %>
           <tr class="t-row">
             <td><%= where_did_you_hear.given_at.to_s(:govuk_date) %></td>
-            <td><%= where_did_you_hear.where_raw %></td>
-            <td><%= where_did_you_hear.where %></td>
+            <td><%= where_did_you_hear.heard_from_raw %></td>
+            <td><%= where_did_you_hear.heard_from %></td>
             <td><%= where_did_you_hear.delivery_partner %></td>
             <td><%= where_did_you_hear.location %></td>
           </tr>

--- a/db/migrate/20160512135735_rename_dumb_attributes.rb
+++ b/db/migrate/20160512135735_rename_dumb_attributes.rb
@@ -1,0 +1,7 @@
+class RenameDumbAttributes < ActiveRecord::Migration
+  def change
+    rename_column :where_did_you_hears, :where, :heard_from
+    rename_column :where_did_you_hears, :where_raw, :heard_from_raw
+    rename_column :where_did_you_hears, :where_code, :heard_from_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160509125257) do
+ActiveRecord::Schema.define(version: 20160512135735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,14 +53,14 @@ ActiveRecord::Schema.define(version: 20160509125257) do
   create_table "where_did_you_hears", force: :cascade do |t|
     t.datetime "given_at",                           null: false
     t.string   "delivery_partner",                   null: false
-    t.string   "where",                 default: "", null: false
+    t.string   "heard_from",            default: "", null: false
     t.string   "pension_provider",      default: "", null: false
     t.string   "location",              default: "", null: false
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
     t.string   "uid",                   default: "", null: false
-    t.string   "where_raw",             default: "", null: false
-    t.string   "where_code",            default: "", null: false
+    t.string   "heard_from_raw",        default: "", null: false
+    t.string   "heard_from_code",       default: "", null: false
     t.string   "pension_provider_code", default: "", null: false
   end
 

--- a/lib/importers/tp/call_record.rb
+++ b/lib/importers/tp/call_record.rb
@@ -11,8 +11,8 @@ module Importers
         {
           uid: uid,
           given_at: given_at,
-          where_raw: where_other,
-          where_code: where_code,
+          heard_from_raw: heard_from_raw,
+          heard_from_code: heard_from_code,
           pension_provider_code: pension_provider_code,
           location: location,
           delivery_partner: DELIVERY_PARTNER
@@ -34,11 +34,11 @@ module Importers
         Time.zone.parse(@row[0].value.strftime('%Y-%m-%d ') + @row[2].value)
       end
 
-      def where_other
+      def heard_from_raw
         @row[13]&.value.to_s
       end
 
-      def where_code
+      def heard_from_code
         @row[12]&.value.to_s
       end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,15 +2,15 @@ FactoryGirl.define do
   factory :where_did_you_hear do
     given_at { Time.zone.now }
     delivery_partner { %w(TPAS NICAB CAS TP).sample }
-    sequence(:where_code) { |i| "WDYH_#{i}" }
-    where 'Pension Provider'
+    sequence(:heard_from_code) { |i| "WDYH_#{i}" }
+    heard_from 'Pension Provider'
     sequence(:pension_provider_code) { |i| "PP_#{i}" }
     pension_provider 'Hargreaves Lansdown'
     location 'Belfast'
 
     before(:create) do |a|
       create(:code_lookup, from: a.pension_provider_code, to: a.pension_provider)
-      create(:code_lookup, from: a.where_code, to: a.where)
+      create(:code_lookup, from: a.heard_from_code, to: a.heard_from)
     end
   end
 

--- a/spec/features/import_tp_call_data_spec.rb
+++ b/spec/features/import_tp_call_data_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
     expect(entry.given_at).to eq('2016-05-04 08:36:17 UTC')
 
     expect(entry).to have_attributes(
-      where: 'Pension Provider',
+      heard_from: 'Pension Provider',
       pension_provider: 'Scottish Widows',
       location: '',
       delivery_partner: 'TP'

--- a/spec/services/where_did_you_hear_csv_spec.rb
+++ b/spec/services/where_did_you_hear_csv_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe WhereDidYouHearCsv do
-  let(:record) { build_stubbed(:where_did_you_hear, where_raw: 'Pension Provider') }
+  let(:record) { build_stubbed(:where_did_you_hear, heard_from_raw: 'Pension Provider') }
   let(:separator) { ',' }
 
   subject { described_class.new(record).call.lines }
@@ -13,9 +13,9 @@ RSpec.describe WhereDidYouHearCsv do
           id
           given_at
           delivery_partner
-          where_raw
-          where_code
-          where
+          heard_from_raw
+          heard_from_code
+          heard_from
           pension_provider
           location
         )
@@ -28,9 +28,9 @@ RSpec.describe WhereDidYouHearCsv do
           record.to_param,
           record.given_at.to_s,
           record.delivery_partner,
-          record.where_raw,
-          record.where_code,
-          record.where,
+          record.heard_from_raw,
+          record.heard_from_code,
+          record.heard_from,
           record.pension_provider,
           record.location
         ]


### PR DESCRIPTION
Naming a column `where`, on reflection, was not the greatest idea. It
seems to have uncovered an issue with quoted naming for reserved words
in Rails. Rather than attempting to resolve this I've decided just to
take the easy route for now and rename the attribute(s).