### PR TITLE
Ensure HTML5 date pickers can be bound

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,3 @@
+default = { default: '%Y-%m-%d' }
+Time::DATE_FORMATS.merge!(default)
+Date::DATE_FORMATS.merge!(default)

--- a/spec/forms/where_did_you_hears_spec.rb
+++ b/spec/forms/where_did_you_hears_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe WhereDidYouHears do
     end
   end
 
+  describe '#start_date and #end_date' do
+    context 'with a datetime, when presenting' do
+      it 'strips the time portion so the field can be bound to an HTML5 date picker' do
+        subject.start_date = subject.end_date = Time.zone.parse('2016-01-01 00:00:00 UTC')
+
+        expect(subject.start_date.to_s).to eq('2016-01-01')
+        expect(subject.end_date.to_s).to eq('2016-01-01')
+      end
+    end
+  end
+
   describe '#paginated_results' do
     let(:page_size_plus_one) { Kaminari.config.default_per_page + 1 }
 


### PR DESCRIPTION
Prior to this change, `#to_s` on date-like objects would include the
time portion, thus causing warnings and unexpected results when
attempting to bind the value to an HTML5 date picker. This change
ensures we strip the time portion when presenting a `DateTime`.

Traditionally, I'd prefer an integration spec that proves this
behaviour, but capybara has problems with HTML5 date pickers so that
proved fruitless.