### PR TITLE
WDYH Summary Tweaks

### DIFF
--- a/app/services/where_did_you_hear_summary.rb
+++ b/app/services/where_did_you_hear_summary.rb
@@ -28,7 +28,7 @@ class WhereDidYouHearSummary
         count: count,
         total: total
       )
-    end
+    end.sort_by(&:count).reverse
   end
   alias rows call
 

--- a/app/services/where_did_you_hear_summary.rb
+++ b/app/services/where_did_you_hear_summary.rb
@@ -1,6 +1,6 @@
 class WhereDidYouHearSummary
   class Row
-    attr_reader :heard_from, :count, :total
+    attr_reader :count, :total
 
     def initialize(heard_from:, count:, total:)
       @heard_from = heard_from
@@ -10,6 +10,10 @@ class WhereDidYouHearSummary
 
     def percentage
       (count.to_f / total.to_f) * 100
+    end
+
+    def heard_from
+      @heard_from.presence || 'N / A'
     end
   end
 

--- a/spec/services/where_did_you_hear_summary_spec.rb
+++ b/spec/services/where_did_you_hear_summary_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe WhereDidYouHearSummary do
       expect(subject.total).to eq(11)
     end
   end
+
+  describe WhereDidYouHearSummary::Row, '#heard_from' do
+    subject { described_class.new(heard_from: '', count: 0, total: 0) }
+
+    context 'when `heard_from` is not present' do
+      it 'returns the N / A label' do
+        expect(subject.heard_from).to eq('N / A')
+      end
+    end
+  end
 end

--- a/spec/services/where_did_you_hear_summary_spec.rb
+++ b/spec/services/where_did_you_hear_summary_spec.rb
@@ -13,10 +13,14 @@ RSpec.describe WhereDidYouHearSummary do
     it 'returns mapped rows grouped by `heard_from`' do
       row = subject.rows.first
 
-      expect(row.heard_from).to eq('Pension Provider')
+      expect(row.heard_from).to eq('Internet')
       expect(row.count).to eq(5)
       expect(row.total).to eq(11)
       expect(row.percentage).to eq(45.45454545454545)
+    end
+
+    it 'is ordered by `count` descending' do
+      expect(subject.rows.map(&:count)).to match_array([5, 5, 1])
     end
   end
 


### PR DESCRIPTION
* Order results by `count` descending
* Display 'N / A' for blank 'heard from' entries

I tested the ordering in memory with a set of 10,000 records and the overheard
is negligible.