### PR TITLE
Ensure ordering is asserted upon

### DIFF
--- a/spec/services/where_did_you_hear_summary_spec.rb
+++ b/spec/services/where_did_you_hear_summary_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe WhereDidYouHearSummary do
     end
 
     it 'is ordered by `count` descending' do
-      expect(subject.rows.map(&:count)).to match_array([5, 5, 1])
+      expect(subject.rows.map(&:count)).to eq([5, 5, 1])
     end
   end
 


### PR DESCRIPTION
`match_array` doesn't respect ordering, dummy.