### PR TITLE
Store raw UID data on WDYH record

### DIFF
--- a/db/migrate/20160519134429_add_raw_field_to_wdyh.rb
+++ b/db/migrate/20160519134429_add_raw_field_to_wdyh.rb
@@ -1,0 +1,5 @@
+class AddRawFieldToWdyh < ActiveRecord::Migration
+  def change
+    add_column :where_did_you_hears, :raw_uid, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512135735) do
+ActiveRecord::Schema.define(version: 20160519134429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20160512135735) do
     t.string   "heard_from_raw",        default: "", null: false
     t.string   "heard_from_code",       default: "", null: false
     t.string   "pension_provider_code", default: "", null: false
+    t.jsonb    "raw_uid"
   end
 
 end

--- a/db/seeds/code_lookups.rb
+++ b/db/seeds/code_lookups.rb
@@ -48,5 +48,6 @@ end
   { from: 'PP_SUNLIFEOC', to: 'Sunlife Financial of Canada' },
   { from: 'PP_ALLIEDDUN', to: 'Allied Dunbar' },
   { from: 'PP_ZURICH', to: 'Zurich' },
-  { from: 'PP_AXA', to: 'AXA' }
+  { from: 'PP_AXA', to: 'AXA' },
+  { from: 'PP_CANNLINC', to: 'Cannon Lincoln' }
 ].each { |attrs| CodeLookup.find_or_create_by!(attrs) }

--- a/lib/importers/tp/call_record.rb
+++ b/lib/importers/tp/call_record.rb
@@ -15,14 +15,19 @@ module Importers
           heard_from_code: heard_from_code,
           pension_provider_code: pension_provider_code,
           location: location,
-          delivery_partner: DELIVERY_PARTNER
+          delivery_partner: DELIVERY_PARTNER,
+          raw_uid: raw_uid
         }
       end
 
       def uid
         md5 = Digest::MD5.new
-        @row[0..13].each { |cell| md5 << cell&.value.to_s }
+        raw_uid.each { |value| md5 << value }
         md5.hexdigest
+      end
+
+      def raw_uid
+        @row[0..13].map { |cell| cell&.value.to_s }
       end
 
       def date


### PR DESCRIPTION
Issue with UID creation resulted in duplicate
entries being created, however we could not 
isolate why. storing this data will allow further
investigation if this happen again.