### PR TITLE
Add WDYH mapping for newspapers/magazine adverts

### DIFF
--- a/lib/importers/smart_survey/call_record.rb
+++ b/lib/importers/smart_survey/call_record.rb
@@ -14,7 +14,7 @@ module Importers
         'TV advert' => 'WDYH_TV',
         'The Pensions Advisory Service (TPAS)' => 'WDYH_TPAS',
         'Radio advert' => 'WDYH_RA',
-        'Newspaper/Magazine advert' => '',
+        'Newspaper/Magazine advert' => 'WDYH_NEWS',
         'Friend/Word of mouth' => 'WDYH_WOM',
         'Local Advertising' => 'WDYH_LA',
         'Job Centre' => 'WDYH_JC',


### PR DESCRIPTION
This requires the underlying WDYH data to be updated 
as follows:

```
WhereDidYouHear
  .where(heard_from_raw: 'Newspaper/Magazine advert')
  .update_all(heard_from_code: 'WDYH_NEWS', heard_from: 'Advertising')
```