### PR TITLE
Add transaction at to handle cancelled timings and fix summary window

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,9 +6,9 @@ class Appointment < ActiveRecord::Base
   validates :uid, uniqueness: true
   validates :delivery_partner, inclusion: { in: Partners.delivery_partners }
 
-  scope :bookings, ->(end_point) { where('booked_at <= ?', end_point).where(cancelled: false) }
-  scope :completions, ->(end_point) { transactions(end_point).where(booking_status: 'Complete') }
-  scope :transactions, ->(end_point) { where('booking_at <= ?', end_point) }
+  scope :bookings, ->(period) { where(booked_at: period, cancelled: false) }
+  scope :completions, ->(period) { transactions(period).where(booking_status: 'Complete') }
+  scope :transactions, ->(period) { where(transaction_at: period) }
   scope :new_today, -> { where(updated_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day, version: 1) }
 
   def increment_version

--- a/db/migrate/20160610105240_create_appointments.rb
+++ b/db/migrate/20160610105240_create_appointments.rb
@@ -4,6 +4,7 @@ class CreateAppointments < ActiveRecord::Migration
       t.string :uid, default: '', null: false
       t.datetime :booked_at, null: false
       t.datetime :booking_at, null: false
+      t.datetime :transaction_at, null: false
       t.boolean :cancelled, default: false
       t.string :booking_status, default: '', null: false, index: true
       t.string :delivery_partner, default: '', null: false, index: true

--- a/db/migrate/20160610105323_create_appointment_versions.rb
+++ b/db/migrate/20160610105323_create_appointment_versions.rb
@@ -4,6 +4,7 @@ class CreateAppointmentVersions < ActiveRecord::Migration
       t.string :uid, default: '', null: false
       t.datetime :booked_at, null: false
       t.datetime :booking_at, null: false
+      t.datetime :transaction_at, null: false
       t.boolean :cancelled, default: false
       t.string :booking_status, default: '', null: false
       t.string :delivery_partner, default: '', null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20160613100914) do
     t.string   "uid",              default: "",    null: false
     t.datetime "booked_at",                        null: false
     t.datetime "booking_at",                       null: false
+    t.datetime "transaction_at",                   null: false
     t.boolean  "cancelled",        default: false
     t.string   "booking_status",   default: "",    null: false
     t.string   "delivery_partner", default: "",    null: false
@@ -46,6 +47,7 @@ ActiveRecord::Schema.define(version: 20160613100914) do
     t.string   "uid",              default: "",    null: false
     t.datetime "booked_at",                        null: false
     t.datetime "booking_at",                       null: false
+    t.datetime "transaction_at",                   null: false
     t.boolean  "cancelled",        default: false
     t.string   "booking_status",   default: "",    null: false
     t.string   "delivery_partner", default: "",    null: false

--- a/lib/importers/booking_bug/record.rb
+++ b/lib/importers/booking_bug/record.rb
@@ -9,7 +9,7 @@ module Importers
         @answers = build_questions_and_answers(data.dig('_embedded', 'answers') || [])
       end
 
-      def params
+      def params_without_transaction_at
         {
           uid: uid,
           booked_at: created_at,
@@ -19,6 +19,12 @@ module Importers
           delivery_partner: Partners::TPAS,
           created_at: updated_at
         }
+      end
+
+      def params
+        transaction_at = is_cancelled ? updated_at : datetime
+
+        params_without_transaction_at.merge(transaction_at: transaction_at)
       end
 
       FIELDS.each do |field|

--- a/lib/importers/booking_bug/saver.rb
+++ b/lib/importers/booking_bug/saver.rb
@@ -2,9 +2,13 @@ module Importers
   module BookingBug
     class Saver
       def self.save(record:)
-        Appointment
-          .find_or_initialize_by(uid: record.uid, delivery_partner: Partners::TPAS)
-          .update_attributes!(record.params)
+        appointment = Appointment.find_or_initialize_by(uid: record.uid, delivery_partner: Partners::TPAS)
+
+        if appointment.cancelled?
+          appointment.update_attributes!(record.params_without_transaction_at)
+        else
+          appointment.update_attributes!(record.params)
+        end
       end
     end
   end

--- a/lib/importers/booking_bug/summary_saver.rb
+++ b/lib/importers/booking_bug/summary_saver.rb
@@ -8,7 +8,7 @@ module Importers
       end
 
       def initialize(period_end)
-        @period_end = period_end
+        @period = period_end.beginning_of_month..period_end
         @reporting_month = period_end.strftime('%Y-%m')
       end
 
@@ -24,15 +24,15 @@ module Importers
       end
 
       def completions
-        Appointment.completions(@period_end).count
+        Appointment.completions(@period).count
       end
 
       def bookings
-        Appointment.bookings(@period_end).count
+        Appointment.bookings(@period).count
       end
 
       def transactions
-        Appointment.transactions(@period_end).count
+        Appointment.transactions(@period).count
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     uid '12345'
     booked_at '2016-06-10 11:52:40'
     booking_at '2016-06-10 11:52:40'
+    transaction_at '2016-06-10 11:52:40'
     cancelled false
     booking_status 'Incomplete'
     delivery_partner { Partners::TPAS }

--- a/spec/features/import_booking_bug_data_spec.rb
+++ b/spec/features/import_booking_bug_data_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
     expect(summary).to eq(
       [
         [0, 3, 0, 'tpas', '2016-05', 'automatic'],
-        [59, 54, 3, 'tpas', '2016-06', 'automatic']
+        [59, 51, 3, 'tpas', '2016-06', 'automatic']
       ]
     )
   end
@@ -139,7 +139,7 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
     expect(summary).to eq(
       [
         [3, 2, 1, 'tpas', '2016-05', 'manual'],
-        [59, 54, 3, 'tpas', '2016-06', 'automatic']
+        [59, 51, 3, 'tpas', '2016-06', 'automatic']
       ]
     )
   end
@@ -148,7 +148,7 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
     expect(summary).to eq(
       [
         [3, 2, 1, 'tpas', '2016-05', 'automatic'],
-        [59, 54, 3, 'tpas', '2016-06', 'automatic']
+        [59, 51, 3, 'tpas', '2016-06', 'automatic']
       ]
     )
   end

--- a/spec/features/import_booking_bug_data_spec.rb
+++ b/spec/features/import_booking_bug_data_spec.rb
@@ -14,6 +14,24 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
            import_all: false
           )
   end
+  let(:cancelled_record) do
+    {
+      'id' => '11111',
+      'datetime' => 1.month.from_now,
+      'updated_at' => Time.zone.now,
+      'created_at' => 1.week.ago,
+      'is_cancelled' => true
+    }
+  end
+  let(:booked_record) do
+    {
+      'id' => '222222',
+      'datetime' => 1.month.from_now,
+      'updated_at' => Time.zone.now,
+      'created_at' => 1.week.ago,
+      'is_cancelled' => false
+    }
+  end
 
   scenario 'Storing booking bug data for use in the Minister For Pensions report' do
     travel_to('2016-06-14 12:00:00') do
@@ -40,6 +58,13 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
     end
   end
 
+  scenario 'Cancelling a booking will modify the transaction date be set to the cancellation date' do
+    given_a_booking_exists_for_next_month
+    when_i_import_booking_bug_data_that_cancels_the_booking
+    then_the_booking_has_a_transaction_date_of_today
+    and_the_booking_is_counted_as_a_transaction_for_the_current_month
+  end
+
   def given_old_booking_bug_data_exists
     create(:appointment, uid: '35943', booking_status: 'Incomplete')
     create(:appointment_summary, transactions: 6, bookings: 5, completions: 4, reporting_month: '2016-06')
@@ -58,8 +83,23 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
     create(:appointment_summary, transactions: 3, bookings: 2, completions: 1, reporting_month: '2016-05')
   end
 
+  def given_a_booking_exists_for_next_month
+    @transaction = create(:appointment, uid: '11111', booking_at: 1.month.from_now, transaction_at: 1.month.from_now)
+  end
+
   def when_i_import_booking_bug_data
     Importers::BookingBug::Importer.new(config: config).import
+  end
+
+  def when_i_import_booking_bug_data_that_cancels_the_booking
+    retriever = instance_double(Importers::BookingBug::Retriever)
+    allow(retriever).to receive(:process_records)
+      .and_yield(cancelled_record)
+      .and_yield(booked_record) # needed to trigger summary recalc
+
+    retriever_klass = double(:retriever_klass, new: retriever)
+
+    Importers::BookingBug::Importer.new(retriever: retriever_klass).import
   end
 
   def then_transaction_data_is_saved
@@ -111,6 +151,15 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
         [59, 54, 3, 'tpas', '2016-06', 'automatic']
       ]
     )
+  end
+
+  def then_the_booking_has_a_transaction_date_of_today
+    @transaction.reload
+    expect(@transaction.transaction_at.to_date).to eq(Time.zone.today)
+  end
+
+  def and_the_booking_is_counted_as_a_transaction_for_the_current_month
+    expect(summary).to eq([[1, 1, 0, 'tpas', Time.zone.today.strftime('%Y-%m'), 'automatic']])
   end
 
   def summary


### PR DESCRIPTION
Cancelled at date should be used when counting transaction (if the booking is cancelled)

Reporting for the month should be for events during the month not for all time.