### PR TITLE
Manual entry appointment summary data

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,4 @@
 @import 'govuk_admin_template';
+
+@import 'lib/variables';
+@import 'components/form-group';

--- a/app/assets/stylesheets/components/_form-group.scss
+++ b/app/assets/stylesheets/components/_form-group.scss
@@ -1,0 +1,17 @@
+.form-group--error {
+  border-left: 5px solid $form-error-color;
+  padding-left: 15px;
+
+  // scss-lint:disable SelectorFormat
+  .field_with_errors label { // override bootstrap style
+    color: $form-default-text-color;
+  }
+  // scss-lint:enable SelectorFormat
+
+  .form-group__error-message {
+    color: $form-error-color;
+    font-weight: bold;
+    padding: 5px 0 7px;
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/lib/_variables.scss
+++ b/app/assets/stylesheets/lib/_variables.scss
@@ -1,0 +1,26 @@
+// hex colours (http://chir.ag/projects/name-that-color/)
+$color-black: #0b0c0c;
+$color-grey-rolling-stone: #6f777b;
+$color-grey-silver-sand: #bfc1c3;
+$color-grey-mercury: #e2e2e2;
+$color-grey-porcelain: #e9ebec;
+$color-grey-alabaster: #f8f8f8;
+$color-grey-black-haze: #f4f5f5;
+$color-white: #fff;
+
+$color-blue-biscay: #17375f;
+$color-blue-endeavour: #005ea5;
+$color-blue-curious: #2b8cc4;
+$color-blue-picton: #5bc8f1;
+$color-orange-pizazz: #fa9600;
+$color-green-atlantis: #97c81e;
+$color-green-jungle: #00385d;
+
+$color-medium-red-violet: #b0348b;
+$color-razmatazz: #e50050;
+
+$color-apple-blossom: #a94442;
+$color-mine-shaft: #333;
+
+$form-error-color: $color-apple-blossom;
+$form-default-text-color: $color-mine-shaft;

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -1,0 +1,75 @@
+class AppointmentSummariesController < ApplicationController
+  before_action :require_edit_permission!, except: [:index, :show]
+
+  def index
+    @appointment_summaries = AppointmentSummaries.new(params[:appointment_summaries])
+  end
+
+  def show
+    @appointment_summaries = AppointmentSummaries.new(reporting_month: params[:id])
+  end
+
+  def new
+    @appointment_summary = AppointmentSummary.new(params.permit(:delivery_partner))
+  end
+
+  def create
+    @appointment_summary = AppointmentSummary.new(appointment_summary_params)
+
+    if @appointment_summary.save
+      redirect_to filtered_appointment_summaries(@appointment_summary)
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @appointment_summary = AppointmentSummary.find(params[:id])
+  end
+
+  def update
+    @appointment_summary = AppointmentSummary.find(params[:id])
+
+    if @appointment_summary.update(appointment_summary_params)
+      redirect_to filtered_appointment_summaries(@appointment_summary)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    appointment_summary = AppointmentSummary.find(params[:id])
+    flash[:notice] =
+      if appointment_summary.manual?
+        appointment_summary.delete
+        "Deleted appointment summary for #{appointment_summary.descripton}"
+      else
+        "Unable to delete automatically generated appointment summary for #{appointment_summary.descripton}"
+      end
+
+    redirect_to filtered_appointment_summaries(appointment_summary)
+  end
+
+  private
+
+  def appointment_summary_params
+    params.require(:appointment_summary).permit(
+      :delivery_partner,
+      :reporting_month,
+      :transactions,
+      :bookings,
+      :completions
+    ).merge(source: 'manual')
+  end
+
+  def require_edit_permission!
+    authorise_user!('analyst')
+  rescue PermissionDeniedException
+    flash[:warning] = 'You do not have the required permissions'
+    redirect_to appointment_summaries_path
+  end
+
+  def filtered_appointment_summaries(appointment_summary)
+    appointment_summaries_path(appointment_summaries: { delivery_partner: appointment_summary.delivery_partner })
+  end
+end

--- a/app/forms/appointment_summaries.rb
+++ b/app/forms/appointment_summaries.rb
@@ -1,0 +1,44 @@
+class AppointmentSummaries
+  include ActiveModel::Model
+
+  ALL = 'all'.freeze
+
+  attr_reader :delivery_partner, :reporting_month
+
+  def initialize(params)
+    params ||= {}
+    @delivery_partner = params.fetch(:delivery_partner, ALL)
+    @reporting_month = params[:reporting_month]
+  end
+
+  def results
+    if reporting_month
+      AppointmentSummary.where(reporting_month: reporting_month)
+    elsif merged?
+      merged_results
+    else
+      AppointmentSummary.where(delivery_partner: delivery_partner)
+    end
+  end
+
+  def filter_options
+    [ALL] + Partners.delivery_partners
+  end
+
+  def merged?
+    delivery_partner == ALL
+  end
+
+  private
+
+  def merged_results
+    AppointmentSummary
+      .group(:reporting_month)
+      .select(
+        :reporting_month,
+        'sum(transactions) as transactions',
+        'sum(bookings) as bookings',
+        'sum(completions) as completions'
+      )
+  end
+end

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -1,9 +1,13 @@
 class AppointmentSummary < ActiveRecord::Base
+  REPORTING_MONTH_REGEXP = /\A\d{2}\-\d{4}\z/
+  REPORTING_MONTH_WRITE_REGEXP = /\A((?<month>\d{2})-(?<year>\d{4})|(?<year>\d{4})-(?<month>\d{2}))\z/
+  REPORTING_MONTH_READ_REGEXP = /\A(?<year>\d{4})-(?<month>\d{2})\z/
+
   validates :source, inclusion:  { in: %w(automatic manual) }, presence: true
   validates :delivery_partner,
             inclusion: { in: Partners.delivery_partners },
             uniqueness: { scope: :reporting_month }
-  validates :reporting_month, format: { with: /\A\d{4}\-\d{2}\z/ }
+  validates :reporting_month, format: REPORTING_MONTH_REGEXP
   validates :completions, numericality: { less_than_or_equal_to: ->(as) { as.transactions } }
 
   default_scope { order(:reporting_month) }
@@ -14,5 +18,25 @@ class AppointmentSummary < ActiveRecord::Base
 
   def descripton
     "#{delivery_partner} #{reporting_month}"
+  end
+
+  def reporting_month
+    if match = super.match(REPORTING_MONTH_READ_REGEXP)
+      "#{match['month']}-#{match['year']}"
+    else
+      super
+    end
+  end
+
+  def reporting_month=(val)
+    if match = val.match(REPORTING_MONTH_WRITE_REGEXP)
+      super("#{match['year']}-#{match['month']}")
+    else
+      super(val)
+    end
+  end
+
+  def raw_reporting_month
+    self[:reporting_month]
   end
 end

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -1,11 +1,18 @@
 class AppointmentSummary < ActiveRecord::Base
-  validates :reporting_month, :source, :delivery_partner, presence: true
-  validates :source, inclusion:  { in: %w(automatic manual) }
-  validates :delivery_partner, inclusion: { in: Partners.delivery_partners }
+  validates :source, inclusion:  { in: %w(automatic manual) }, presence: true
+  validates :delivery_partner,
+            inclusion: { in: Partners.delivery_partners },
+            uniqueness: { scope: :reporting_month }
+  validates :reporting_month, format: { with: /\A\d{4}\-\d{2}\z/ }
+  validates :completions, numericality: { less_than_or_equal_to: ->(as) { as.transactions } }
 
   default_scope { order(:reporting_month) }
 
   def manual?
     source == 'manual'
+  end
+
+  def descripton
+    "#{delivery_partner} #{reporting_month}"
   end
 end

--- a/app/views/appointment_summaries/_error.html.erb
+++ b/app/views/appointment_summaries/_error.html.erb
@@ -1,0 +1,3 @@
+<% if error_messages.any? %>
+  <%= simple_format error_messages.join("\n"), { class: 'form-group__error-message' }, wrapper_tag: 'span' %>
+<% end %>

--- a/app/views/appointment_summaries/_form.html.erb
+++ b/app/views/appointment_summaries/_form.html.erb
@@ -1,13 +1,13 @@
 <div class="form-group <%= 'form-group--error' if f.object.errors[:delivery_partner].any? %>">
   <%= f.label :delivery_partner %>
   <%= render 'error', error_messages: f.object.errors[:delivery_partner] %>
-  <%= f.select :delivery_partner, Partners.delivery_partners, { include_blank: true }, class: 'input-md-3 form-control t-delivery_partner text-uppercase' %>
+  <%= f.select :delivery_partner, Partners.delivery_partners, { include_blank: true }, class: 'input-md-3 form-control t-delivery-partner text-uppercase' %>
 </div>
 
 <div class="form-group <%= 'form-group--error' if f.object.errors[:reporting_month].any? %>">
   <%= f.label :reporting_month %>
   <%= render 'error', error_messages: f.object.errors[:reporting_month] %>
-  <%= f.text_field :reporting_month, class: 'input-md-3 form-control t-period_end', placeholder: 'YYYY-MM' %>
+  <%= f.text_field :reporting_month, class: 'input-md-3 form-control t-reporting-month', placeholder: 'MM-YYYY' %>
 </div>
 
 <div class="form-group <%= 'form-group--error' if f.object.errors[:transactions].any? %>">

--- a/app/views/appointment_summaries/_form.html.erb
+++ b/app/views/appointment_summaries/_form.html.erb
@@ -1,0 +1,31 @@
+<div class="form-group <%= 'form-group--error' if f.object.errors[:delivery_partner].any? %>">
+  <%= f.label :delivery_partner %>
+  <%= render 'error', error_messages: f.object.errors[:delivery_partner] %>
+  <%= f.select :delivery_partner, Partners.delivery_partners, { include_blank: true }, class: 'input-md-3 form-control t-delivery_partner text-uppercase' %>
+</div>
+
+<div class="form-group <%= 'form-group--error' if f.object.errors[:reporting_month].any? %>">
+  <%= f.label :reporting_month %>
+  <%= render 'error', error_messages: f.object.errors[:reporting_month] %>
+  <%= f.text_field :reporting_month, class: 'input-md-3 form-control t-period_end', placeholder: 'YYYY-MM' %>
+</div>
+
+<div class="form-group <%= 'form-group--error' if f.object.errors[:transactions].any? %>">
+  <%= f.label :transactions %>
+  <%= render 'error', error_messages: f.object.errors[:transactions] %>
+  <%= f.text_field :transactions, class: 'input-md-3 form-control t-transactions' %>
+</div>
+
+<div class="form-group <%= 'form-group--error' if f.object.errors[:bookings].any? %>">
+  <%= f.label :bookings %>
+  <%= render 'error', error_messages: f.object.errors[:bookings] %>
+  <%= f.text_field :bookings, class: 'input-md-3 form-control t-bookings' %>
+</div>
+
+<div class="form-group <%= 'form-group--error' if f.object.errors[:completions].any? %>">
+  <%= f.label :completions %>
+  <%= render 'error', error_messages: f.object.errors[:completions] %>
+  <%= f.text_field :completions, class: 'input-md-3 form-control t-completions' %>
+</div>
+
+

--- a/app/views/appointment_summaries/edit.html.erb
+++ b/app/views/appointment_summaries/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>Edit appointment summary</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for @appointment_summary do |f| %>
+      <%= render 'form', f: f %>
+
+      <div class="form-group">
+        <%= link_to 'Cancel', appointment_summaries_path, class: 'btn btn-default' %>
+        <%= f.submit 'Update', class: 'btn btn-success t-update-button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/appointment_summaries/index.html.erb
+++ b/app/views/appointment_summaries/index.html.erb
@@ -1,0 +1,54 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>Appointment Summaries</h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for @appointment_summaries, url: appointment_summaries_path, method: 'get' do |f| %>
+      <div class="form-group">
+        <%= f.label :delivery_partner %>
+        <%= f.select :delivery_partner, @appointment_summaries.filter_options, {}, class: 'input-md-3 form-control t-delivery_partner inline-block text-uppercase' %>
+        <%= f.submit 'Filter', class: 'btn btn-default t-filter-submit' %>
+        <%= link_to 'Create manual entry', new_appointment_summary_path(delivery_partner: @appointment_summaries.delivery_partner), class: 'btn btn-success' %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <% if @appointment_summaries.results.empty? %>
+      <p class="no-content t-notice">No appointment summaries available with those filter options.</p>
+    <% else %>
+      <table class="table">
+        <thead>
+          <th>Reporting month</th>
+          <th>Bookings</th>
+          <th>Completions</th>
+          <th>Transactions</th>
+          <th></th>
+        </thead>
+        <tbody>
+          <% @appointment_summaries.results.each do |summary| %>
+            <tr>
+              <td><%= summary.reporting_month %></td>
+              <td><%= summary.bookings %></td>
+              <td><%= summary.completions %></td>
+              <td><%= summary.transactions %></td>
+              <td>
+                <% if @appointment_summaries.merged? %>
+                  <%= link_to "By delivery partner", appointment_summary_path(summary.raw_reporting_month), class: 'btn btn-default' %>
+                <% else %>
+                  <%= link_to "Edit", edit_appointment_summary_path(summary), class: 'btn btn-default inline' %>
+                  <%= button_to "Delete", summary, method: :delete, class: 'btn btn-danger', form: { class: 'inline' } if summary.manual? %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,0 +1,17 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>New appointment summary</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for @appointment_summary do |f| %>
+      <%= render 'form', f: f %>
+
+      <div class="form-group">
+        <%= link_to 'Cancel', appointment_summaries_path, class: 'btn btn-default' %>
+        <%= f.submit 'Create', class: 'btn btn-success t-create-button' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/appointment_summaries/show.html.erb
+++ b/app/views/appointment_summaries/show.html.erb
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>Appointment Summaries - <%= @appointment_summaries.reporting_month %></h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <% if @appointment_summaries.results.empty? %>
+      <p class="no-content t-notice">No appointment summaries available with those filter options.</p>
+    <% else %>
+      <table class="table">
+        <thead>
+          <th>Delivery partner</th>
+          <th>Bookings</th>
+          <th>Completions</th>
+          <th>Transactions</th>
+          <th></th>
+        </thead>
+        <tbody>
+          <% @appointment_summaries.results.each do |summary| %>
+            <tr>
+              <td><%= summary.delivery_partner.upcase %></td>
+              <td><%= summary.bookings %></td>
+              <td><%= summary.completions %></td>
+              <td><%= summary.transactions %></td>
+              <td>
+                <%= link_to "Edit", edit_appointment_summary_path(summary), class: 'btn btn-default inline' %>
+                <%= button_to "Delete", summary, method: :delete, class: 'btn btn-danger', form: { class: 'inline' } if summary.manual? %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
 
 <%= content_for :navbar_items do %>
   <li>
+    <%= link_to 'Appointments', appointment_summaries_path %>
+  </li>
+  <li>
     <%= link_to 'Call volumes', call_volumes_path %>
   </li>
   <li>

--- a/config/initializers/show_flash.rb
+++ b/config/initializers/show_flash.rb
@@ -1,0 +1,3 @@
+GovukAdminTemplate.configure do |c|
+  c.show_flash = true
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,10 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        appointment_summary:
+          attributes:
+            reporting_month:
+              invalid: does not match required format
+            completions:
+              less_than_or_equal_to: must be less than 'transactions'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
 
   root 'reports#call_volumes'
 
+  resources :appointment_summaries
+
   mount Sidekiq::Web => '/sidekiq', constraint: AuthenticatedUser.new
 end

--- a/db/migrate/20160616130135_populate_historical_appointment_summary_data.rb
+++ b/db/migrate/20160616130135_populate_historical_appointment_summary_data.rb
@@ -1,0 +1,55 @@
+require 'csv'
+
+class PopulateHistoricalAppointmentSummaryData < ActiveRecord::Migration
+  DATA = <<~CSV
+    Month,CITA Bookings,CAS Bookings,NICAB Bookings,TPAS Bookings,CITA Transactions,CAS Transactions,NICAB Transactions,TPAS Transactions,CITA Completions,CAS Completions,NICAB Completions,TPAS Completions
+    Apr-15,1364,319,0,2948,1498,179,0,2340,1423,170,0,1404
+    May-15,1794,316,137,1877,1961,299,137,2463,1830,293,137,1598
+    Jun-15,1872,276,205,1517,1871,274,205,1792,1846,276,213,1243
+    Jul-15,2626,338,185,2052,2665,298,185,2237,2037,264,185,1540
+    Aug-15,3557,323,255,1253,2513,298,255,1488,1771,218,255,1065
+    Sep-15,3539,412,309,1573,3074,340,288,1570,2208,310,288,1080
+    Oct-15,4175,416,341,1412,4642,395,306,1412,3749,378,306,977
+    Nov-15,3061,378,307,1090,3521,358,291,1195,3203,332,291,956
+    Dec-15,1624,176,123,695,2106,230,124,745,1924,215,124,628
+    Jan-16,2718,373,245,1313,2718,276,221,1211,2718,276,221,846
+    Feb-16,3924,388,358,1520,3745,392,343,1436,3423,331,343,1142
+    Mar-16,4903,453,243,2555,4347,406,188,2061,3869,402,188,1586
+    Apr-16,4123,366,191,1707,4321,369,202,2010,3793,336,202,1577
+    May-16,2925,275,172,1210,3128,276,150,1301,2771,264,150,1070
+  CSV
+
+  def up
+    return if Rails.env.test?
+
+    data = CSV.parse(DATA, headers: true)
+    data.each do |month_row|
+      create_appointment_summary(data: month_row, delivery_partner: 'cas')
+      create_appointment_summary(data: month_row, delivery_partner: 'cita')
+      create_appointment_summary(data: month_row, delivery_partner: 'nicab')
+      create_appointment_summary(data: month_row, delivery_partner: 'tpas')
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def create_appointment_summary(data:, delivery_partner:)
+    summary = AppointmentSummary.find_or_initialize_by(
+      delivery_partner: delivery_partner,
+      reporting_month: reporting_month(data['Month'])
+    )
+
+    summary.transactions = data["#{delivery_partner.upcase} Transactions"]
+    summary.bookings = data["#{delivery_partner.upcase} Bookings"]
+    summary.completions = data["#{delivery_partner.upcase} Completions"]
+    summary.source = 'manual'
+
+    summary.save!
+  end
+
+  def reporting_month(val)
+    Date.parse("01-#{val}").strftime('%m-%Y')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160613100914) do
+ActiveRecord::Schema.define(version: 20160616130135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/manual_appointment_summary_data.feature
+++ b/features/manual_appointment_summary_data.feature
@@ -1,0 +1,20 @@
+Feature: Manual appointment summary data
+  As a Pension Wise data analyst
+  I want to be able to manually input appointment summary data
+  So to generate reports when the source data can not be automatically imported
+
+  Scenario: I can manually create an appointment summary record
+    Given I am logged in as a Pension Wise data analyst
+    When I create a new appointment summary record
+    Then the appointment summary record is successfully saved
+
+  Scenario: I can override a automatically generated appointment summary record
+    Given I am logged in as a Pension Wise data analyst
+    And an existing automatically generated appointment summary record exists
+    When I edit the appointment summary record
+    Then my changes are saved and the record is marked as a manually generated appointment summary record
+
+  Scenario: I require edit permission to access edit manual appointment summary records
+    Given I am logged in as a Pension Wise user - non analyst
+    When I attempt to create a new appointment summary record
+    Then I am redirected away with the notice "You do not have the required permissions"

--- a/features/pages/edit_appointment_summary_page.rb
+++ b/features/pages/edit_appointment_summary_page.rb
@@ -1,0 +1,11 @@
+class EditAppointmentSummaryPage < SitePrism::Page
+  set_url '/appointment_summaries/{id}/edit'
+
+  element :delivery_partner, '.t-delivery_partner'
+  element :period_end, '.t-period_end'
+  element :transactions, '.t-transactions'
+  element :bookings, '.t-bookings'
+  element :completions, '.t-completions'
+
+  element :update_button, '.t-update-button'
+end

--- a/features/pages/edit_appointment_summary_page.rb
+++ b/features/pages/edit_appointment_summary_page.rb
@@ -1,8 +1,8 @@
 class EditAppointmentSummaryPage < SitePrism::Page
   set_url '/appointment_summaries/{id}/edit'
 
-  element :delivery_partner, '.t-delivery_partner'
-  element :period_end, '.t-period_end'
+  element :delivery_partner, '.t-delivery-partner'
+  element :reporting_month, '.t-reporting-month'
   element :transactions, '.t-transactions'
   element :bookings, '.t-bookings'
   element :completions, '.t-completions'

--- a/features/pages/new_appointment_summary_page.rb
+++ b/features/pages/new_appointment_summary_page.rb
@@ -1,8 +1,8 @@
 class NewAppointmentSummaryPage < SitePrism::Page
   set_url '/appointment_summaries/new'
 
-  element :delivery_partner, '.t-delivery_partner'
-  element :period_end, '.t-period_end'
+  element :delivery_partner, '.t-delivery-partner'
+  element :reporting_month, '.t-reporting-month'
   element :transactions, '.t-transactions'
   element :bookings, '.t-bookings'
   element :completions, '.t-completions'

--- a/features/pages/new_appointment_summary_page.rb
+++ b/features/pages/new_appointment_summary_page.rb
@@ -1,0 +1,11 @@
+class NewAppointmentSummaryPage < SitePrism::Page
+  set_url '/appointment_summaries/new'
+
+  element :delivery_partner, '.t-delivery_partner'
+  element :period_end, '.t-period_end'
+  element :transactions, '.t-transactions'
+  element :bookings, '.t-bookings'
+  element :completions, '.t-completions'
+
+  element :create_button, '.t-create-button'
+end

--- a/features/step_definitions/appointment_summary_steps.rb
+++ b/features/step_definitions/appointment_summary_steps.rb
@@ -13,7 +13,7 @@ When(/^I create a new appointment summary record$/) do
   @page.load
 
   @page.delivery_partner.select(Partners::TPAS)
-  @page.period_end.set('2016-05')
+  @page.reporting_month.set('05-2016')
   @page.transactions.set(100)
   @page.bookings.set(80)
   @page.completions.set(60)
@@ -31,7 +31,7 @@ When(/^I edit the appointment summary record$/) do
   @page.load(id: @transaction.id)
 
   @page.delivery_partner.select(Partners::TPAS)
-  @page.period_end.set('2016-05')
+  @page.reporting_month.set('05-2016')
   @page.transactions.set(100)
   @page.bookings.set(80)
   @page.completions.set(60)
@@ -46,7 +46,7 @@ end
 Then(/^the appointment summary record is successfully saved$/) do
   expect(AppointmentSummary.last).to have_attributes(
     delivery_partner: Partners::TPAS,
-    reporting_month: '2016-05',
+    reporting_month: '05-2016',
     transactions: 100,
     bookings: 80,
     completions: 60,
@@ -58,7 +58,7 @@ Then(/^my changes are saved and the record is marked as a manually generated app
   @transaction.reload
   expect(@transaction).to have_attributes(
     delivery_partner: Partners::TPAS,
-    reporting_month: '2016-05',
+    reporting_month: '05-2016',
     transactions: 100,
     bookings: 80,
     completions: 60,

--- a/features/step_definitions/appointment_summary_steps.rb
+++ b/features/step_definitions/appointment_summary_steps.rb
@@ -1,0 +1,67 @@
+Given(/^an existing automatically generated appointment summary record exists$/) do
+  @transaction = create(
+    :appointment_summary,
+    reporting_month: '2016-05',
+    transactions: 200,
+    bookings: 150,
+    completions: 25
+  )
+end
+
+When(/^I create a new appointment summary record$/) do
+  @page = NewAppointmentSummaryPage.new
+  @page.load
+
+  @page.delivery_partner.select(Partners::TPAS)
+  @page.period_end.set('2016-05')
+  @page.transactions.set(100)
+  @page.bookings.set(80)
+  @page.completions.set(60)
+
+  @page.create_button.click
+end
+
+When(/^I attempt to create a new appointment summary record$/) do
+  @page = NewAppointmentSummaryPage.new
+  @page.load
+end
+
+When(/^I edit the appointment summary record$/) do
+  @page = EditAppointmentSummaryPage.new
+  @page.load(id: @transaction.id)
+
+  @page.delivery_partner.select(Partners::TPAS)
+  @page.period_end.set('2016-05')
+  @page.transactions.set(100)
+  @page.bookings.set(80)
+  @page.completions.set(60)
+
+  @page.update_button.click
+end
+
+Then(/^I am redirected away with the notice "([^"]*)"$/) do |_notice|
+  expect(@page).not_to be_displayed
+end
+
+Then(/^the appointment summary record is successfully saved$/) do
+  expect(AppointmentSummary.last).to have_attributes(
+    delivery_partner: Partners::TPAS,
+    reporting_month: '2016-05',
+    transactions: 100,
+    bookings: 80,
+    completions: 60,
+    source: 'manual'
+  )
+end
+
+Then(/^my changes are saved and the record is marked as a manually generated appointment summary record$/) do
+  @transaction.reload
+  expect(@transaction).to have_attributes(
+    delivery_partner: Partners::TPAS,
+    reporting_month: '2016-05',
+    transactions: 100,
+    bookings: 80,
+    completions: 60,
+    source: 'manual'
+  )
+end

--- a/features/step_definitions/call_volumes_report_steps.rb
+++ b/features/step_definitions/call_volumes_report_steps.rb
@@ -1,14 +1,3 @@
-Given(/^I am logged in as a Pension Wise data analyst$/) do
-  User.create!(
-    name: 'Data analyst',
-    email: 'analyst@pensionwise.gov.uk',
-    uid: SecureRandom.uuid,
-    permissions: ['signin'],
-    remotely_signed_out: false,
-    disabled: false
-  )
-end
-
 Given(/^there are existing daily call volumes for (Twilio|the contact centre)$/) do |source|
   @call_volumes = {}
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -1,0 +1,7 @@
+Given(/^I am logged in as a Pension Wise data analyst$/) do
+  create(:user, permissions: %w(signin analyst))
+end
+
+Given(/^I am logged in as a Pension Wise user - non analyst$/) do
+  create(:user, permissions: %w(signin))
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,4 +40,13 @@ FactoryGirl.define do
     from 'PP_HL'
     to 'Hargreaves Lansdown'
   end
+
+  factory :user do
+    name 'Data analyst'
+    email 'analyst@pensionwise.gov.uk'
+    uid SecureRandom.uuid
+    permissions []
+    remotely_signed_out false
+    disabled false
+  end
 end


### PR DESCRIPTION
Allow manual creation/and deletion of appointment summary data.

`/appointment_summaries` shows appointment figures by month for the filtered delivery partner

`/appointment_summaries/<reporting_month>` shows appointment for the selected month by delivery partner

