### PR TITLE
Rubocop: allow assignment in condition without brackets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Rails:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false


### PR DESCRIPTION
Make the following line valid:

```
if apples = find_fruit(:red)
  apples.grow
end
```

Where previously it would have required the assignment
to be wrapped in brackets.