### PR TITLE
Exclude Booking bug appointments with invalid service name

### DIFF
--- a/lib/importers/booking_bug/importer.rb
+++ b/lib/importers/booking_bug/importer.rb
@@ -18,6 +18,7 @@ module Importers
         ActiveRecord::Base.transaction do
           @retriever.process_records do |row_data|
             record = @record.new(row_data)
+            next unless record.valid?
             @saver.save(record: record)
           end
           @summary_saver.save(Partners::TPAS)

--- a/lib/importers/booking_bug/record.rb
+++ b/lib/importers/booking_bug/record.rb
@@ -1,8 +1,9 @@
 module Importers
   module BookingBug
     class Record
-      FIELDS = %w(id datetime updated_at created_at is_cancelled).freeze
+      FIELDS = %w(id datetime updated_at created_at is_cancelled service_name).freeze
       DEFAULT_BOOKING_STATUS = 'Awaiting Status'.freeze
+      PENSIONWISE_APPOINTMENT = 'Pensionwise Callback'.freeze
 
       def initialize(data)
         @row = data.slice(*FIELDS)
@@ -46,6 +47,10 @@ module Importers
 
           hash[question] = answer if answer.present?
         end
+      end
+
+      def valid?
+        service_name == PENSIONWISE_APPOINTMENT
       end
     end
   end

--- a/spec/features/import_booking_bug_data_spec.rb
+++ b/spec/features/import_booking_bug_data_spec.rb
@@ -20,7 +20,8 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
       'datetime' => 1.month.from_now,
       'updated_at' => Time.zone.now,
       'created_at' => 1.week.ago,
-      'is_cancelled' => true
+      'is_cancelled' => true,
+      'service_name' => Importers::BookingBug::Record::PENSIONWISE_APPOINTMENT
     }
   end
   let(:booked_record) do
@@ -29,7 +30,8 @@ RSpec.feature 'Importing booking bug data', vcr: { cassette_name: 'booking_bug_d
       'datetime' => 1.month.from_now,
       'updated_at' => Time.zone.now,
       'created_at' => 1.week.ago,
-      'is_cancelled' => false
+      'is_cancelled' => false,
+      'service_name' => Importers::BookingBug::Record::PENSIONWISE_APPOINTMENT
     }
   end
 


### PR DESCRIPTION
These are caused by blocking out the guiders diary

__NOTE:__

This will require a purge and reimport of all TPAS appointment data