### PR TITLE
Extend BookingBug data import window

### DIFF
--- a/lib/importers/booking_bug/retriever.rb
+++ b/lib/importers/booking_bug/retriever.rb
@@ -5,6 +5,7 @@ require 'response_logger'
 module Importers
   module BookingBug
     class Retriever
+      IMPORT_WINDOW = 90.days
       AUTH_URL = '/api/v1/login'.freeze
 
       def initialize(config:)
@@ -34,7 +35,7 @@ module Importers
       end
 
       def modified_since
-        Time.zone.yesterday.strftime('%Y-%m-%dT00:00:00')
+        IMPORT_WINDOW.ago.strftime('%Y-%m-%dT00:00:00')
       end
 
       def conn

--- a/spec/cassettes/booking_bug_data.yml
+++ b/spec/cassettes/booking_bug_data.yml
@@ -71,7 +71,7 @@ http_interactions:
   recorded_at: Tue, 14 Jun 2016 11:00:00 GMT
 - request:
     method: get
-    uri: https://booking.pensionwise.gov.uk/api/v1/admin/treasuryw2693708/bookings?include_cancelled=true&modified_since=2016-06-13T00:00:00&page=1&per_page=100
+    uri: https://booking.pensionwise.gov.uk/api/v1/admin/treasuryw2693708/bookings?include_cancelled=true&modified_since=2016-03-16T00:00:00&page=1&per_page=100
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Changing to Booking status doesn't appear to update 
the last modified time on the record. Given max lead 
time to an appointment of 6 week, 90 days (approx 12 weeks)
should mean we capture all updates without having to 
import the full dataset each day.