### PR TITLE
Store Twilio call records

### DIFF
--- a/app/models/twilio_call.rb
+++ b/app/models/twilio_call.rb
@@ -1,0 +1,7 @@
+class TwilioCall < ActiveRecord::Base
+  validates :uid, :inbound_number, :called_at,
+            presence: true
+  validates :outcome,
+            inclusion: %w(forwarded abandoned failed)
+  validates :delivery_partner, inclusion: { in: Partners.face_to_face, allow_blank: true }
+end

--- a/config/initializers/importers.rb
+++ b/config/initializers/importers.rb
@@ -3,6 +3,12 @@ Rails.configuration.x.twilio.tap do |twilio|
   twilio.account_sid = ENV['TWILIO_ACCOUNT_SID']
 end
 
+Rails.configuration.x.locations.tap do |locations|
+  locations.bearer_token = ENV['LOCATIONS_API_BEARER_TOKEN']
+  locations.api_uri = ENV.fetch('LOCATIONS_API_URI', 'http://localhost:3001')
+  locations.read_timeout = ENV.fetch('LOCATIONS_API_READ_TIMEOUT', 5).to_i
+end
+
 Rails.configuration.x.tp.tap do |tp|
   tp.user_name = ENV['TP_USER_NAME']
   tp.password = ENV['TP_PASSWORD']

--- a/db/migrate/20160817132701_create_twilio_calls.rb
+++ b/db/migrate/20160817132701_create_twilio_calls.rb
@@ -1,0 +1,21 @@
+class CreateTwilioCalls < ActiveRecord::Migration
+  def change
+    create_table :twilio_calls do |t|
+      t.string :uid
+      t.datetime :called_at
+      t.string :inbound_number
+      t.string :outbound_number
+      t.integer :call_duration
+      t.decimal :cost, precision: 10, scale: 4
+      t.string :outcome
+      t.string :delivery_partner
+      t.string :location_uid
+      t.string :location
+      t.string :location_postcode
+      t.string :booking_location
+      t.string :booking_location_postcode
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804103616) do
+ActiveRecord::Schema.define(version: 20160817132701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,24 @@ ActiveRecord::Schema.define(version: 20160804103616) do
     t.string   "location",         default: "", null: false
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+  end
+
+  create_table "twilio_calls", force: :cascade do |t|
+    t.string   "uid"
+    t.datetime "called_at"
+    t.string   "inbound_number"
+    t.string   "outbound_number"
+    t.integer  "call_duration"
+    t.decimal  "cost",                      precision: 10, scale: 4
+    t.string   "outcome"
+    t.string   "delivery_partner"
+    t.string   "location_uid"
+    t.string   "location"
+    t.string   "location_postcode"
+    t.string   "booking_location"
+    t.string   "booking_location_postcode"
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
   end
 
   create_table "uploaded_files", force: :cascade do |t|

--- a/lib/importers/twilio.rb
+++ b/lib/importers/twilio.rb
@@ -2,6 +2,7 @@ module Importers
   module Twilio
     autoload :CallRecord, 'importers/twilio/call_record'
     autoload :Importer, 'importers/twilio/importer'
+    autoload :TwilioLookup, 'importers/twilio/twilio_lookup'
     autoload :Retriever, 'importers/twilio/retriever'
     autoload :Saver, 'importers/twilio/saver'
   end

--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -3,35 +3,95 @@ module Importers
     class CallRecord
       MINIMUM_CALL_TIME = 10
 
-      def initialize(calls)
+      def params # rubocop:disable Metrics/MethodLength
+        {
+          uid: uid,
+          called_at: called_at,
+          inbound_number: inbound_number,
+          outbound_number: outbound_number,
+          call_duration: outbound_call_duration,
+          cost: cost,
+          outcome: outcome,
+          delivery_partner: @location_details['delivery_partner'],
+          location_uid: @location_details['uid'],
+          location: @location_details['location'],
+          location_postcode: @location_details['location_postcode'],
+          booking_location: @location_details['booking_location'],
+          booking_location_postcode: @location_details['booking_location_postcode']
+        }
+      end
+
+      def initialize(calls, location_details)
         @inbound_call, @outbound_call = *calls
+        @location_details = location_details
+      end
+
+      def uid
+        @inbound_call.parent_call_sid || @inbound_call.sid
+      end
+
+      def called_at
+        Time.zone.parse(@inbound_call.start_time)
       end
 
       def date
-        Time.zone.parse(@inbound_call.start_time).utc.to_date
+        called_at.utc.to_date
+      end
+
+      def inbound_number
+        @inbound_call.to
+      end
+
+      def outbound_number
+        @outbound_call&.to
+      end
+
+      def outbound_call_duration
+        @outbound_call&.duration.to_i
+      end
+
+      def cost
+        BigDecimal(@inbound_call.price) + (@outbound_call ? BigDecimal(@outbound_call.price) : 0)
+      end
+
+      def outcome
+        return 'failed' unless @outbound_call
+        valid? ? 'forwarded' : 'abandoned'
       end
 
       def valid?
-        @outbound_call.duration.to_i > MINIMUM_CALL_TIME
+        outbound_call_duration > MINIMUM_CALL_TIME
       end
 
       class << self
-        def build(calls)
+        def build(calls:, twilio_lookup:)
           grouped_calls = calls.sort_by(&:start_time).group_by { |record| record.parent_call_sid || record.sid }
 
-          valid_pairs, invalid_pairs = grouped_calls.values.partition { |call_group| call_group.count == 2 }
+          valid_pairs, invalid_pairs = partition(grouped_calls.values)
 
           invalid_pairs.each { |invalid_pair| log(invalid_pair) }
-          valid_pairs.map { |valid_pair| new(valid_pair) }
+          valid_pairs.map do |call_pair|
+            new(
+              call_pair,
+              twilio_lookup.call(call_pair.first.to)
+            )
+          end
         end
 
         private
+
+        def partition(call_pairs)
+          call_pairs.partition do |call_group|
+            call_group.count == 2 ||
+              (call_group.count == 1 && call_group.first.direction == 'inbound')
+          end
+        end
 
         def log(calls)
           call_details = calls.map do |call|
             "At: #{call.start_time} Duration: #{call.duration} Sid: #{call.sid} ParentSid: #{call.parent_call_sid}"
           end
-          Rails.logger.warn("Twilio unpaired calls: #{call_details.join(', ')}")
+          Rails.logger.warn("Twilio unpaired calls (#{call_details.count}): #{call_details.join(', ')}")
         end
       end
     end

--- a/lib/importers/twilio/importer.rb
+++ b/lib/importers/twilio/importer.rb
@@ -1,16 +1,23 @@
 module Importers
   module Twilio
     class Importer
-      def initialize(retriever: Retriever, call_record: CallRecord, saver: Saver, config: Rails.configuration.x.twilio)
+      def initialize(
+        retriever: Retriever,
+        call_record: CallRecord,
+        saver: Saver,
+        twilio_lookup: TwilioLookup.new,
+        config: Rails.configuration.x.twilio
+      )
         @retriever = retriever.new(config: config)
         @call_record = call_record
         @saver = saver
+        @twilio_lookup = twilio_lookup
       end
 
       def import(start_date:, end_date:)
         raw_calls = @retriever.from_api(start_date: start_date, end_date: end_date)
-        calls = @call_record.build(raw_calls)
-        @saver.new(calls: calls).store_valid_by_date
+        calls = @call_record.build(calls: raw_calls, twilio_lookup: @twilio_lookup)
+        @saver.new(calls: calls).save
       end
     end
   end

--- a/lib/importers/twilio/twilio_lookup.rb
+++ b/lib/importers/twilio/twilio_lookup.rb
@@ -1,0 +1,21 @@
+require 'location_api'
+
+module Importers
+  module Twilio
+    class TwilioLookup
+      def initialize(config: Rails.configuration.x.locations)
+        @config = config
+      end
+
+      def call(twilio_number)
+        twilio_numbers.fetch(twilio_number, {})
+      end
+
+      private
+
+      def twilio_numbers
+        @twilio_numbers ||= LocationApi.new(config: @config).all['twilio_numbers']
+      end
+    end
+  end
+end

--- a/lib/location_api.rb
+++ b/lib/location_api.rb
@@ -1,0 +1,22 @@
+require 'open-uri'
+
+class LocationApi
+  def initialize(config:)
+    @config = config
+  end
+
+  def all
+    response = open("#{@config.api_uri}/api/v1/twilio_numbers.json", headers_and_options)
+    JSON.parse(response.read)
+  end
+
+  private
+
+  def headers_and_options
+    {}.tap do |hash|
+      hash[:read_timeout]   = @config.read_timeout
+      hash['Authorization'] = "Bearer #{@config.bearer_token}" if @config.bearer_token
+      hash['Accept'] = 'application/json'
+    end
+  end
+end

--- a/spec/features/import_twilio_call_data_spec.rb
+++ b/spec/features/import_twilio_call_data_spec.rb
@@ -5,16 +5,50 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
   let(:start_date) { Date.new(2016, 4, 11) }
   let(:end_date) { Date.new(2016, 4, 12) }
   let(:config) { double(account_sid: 'ACCOUNT_SID', auth_token: 'AUTH_TOKEN') }
+  let(:call_params) do
+    {
+      uid: 'CA7eb4d3924e3e73e9ef0dcad70b3b46fa',
+      inbound_number: 'inbound',
+      outbound_number: 'outbound',
+      call_duration: 24,
+      called_at: Time.zone.parse('2016-08-20 11:26:35'),
+      cost: -0.015,
+      outcome: 'forwarded',
+      delivery_partner: 'cita',
+      location_uid: 'uid',
+      location: 'location',
+      location_postcode: 'location_postcode',
+      booking_location: 'booking_location',
+      booking_location_postcode: 'booking_location_postcode'
+    }
+  end
 
   scenario 'Storing daily call volumes for use in the Minister For Pensions report' do
     when_i_import_twilio_data
     then_the_daily_call_volume_for_twilio_should_be_saved
   end
 
+  scenario 'Storing call records' do
+    when_i_import_twilio_data
+    then_twilio_call_data_should_be_created
+  end
+
+  scenario 'Storing call records with location details' do
+    given_location_details_exist
+    when_i_import_twilio_data
+    then_twilio_call_data_should_be_created
+  end
+
   scenario 'Updating daily call volumes' do
     given_old_daily_call_volumes_exists
     when_i_import_twilio_data
     then_the_daily_call_volume_for_twilio_should_be_updated
+  end
+
+  scenario 'It does not update existsing call records' do
+    given_a_call_record_exists
+    when_i_import_twilio_data
+    the_call_record_has_not_been_changed
   end
 
   def given_old_daily_call_volumes_exists
@@ -24,8 +58,26 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
     )
   end
 
+  def given_location_details_exist
+    @twilio_lookup_response = {
+      'uid' => 'c002c214-7a39-4ff2-b21f-a4f3b45b14a1',
+      'delivery_partner' => 'cas',
+      'location' => 'Aberdeen',
+      'location_postcode' => 'AB11 5BN',
+      'booking_location' => 'Aberdeen',
+      'booking_location_postcode' => 'AB11 5BN'
+    }
+  end
+
+  def given_a_call_record_exists
+    TwilioCall.create!(call_params)
+  end
+
   def when_i_import_twilio_data
-    Importers::Twilio::Importer.new(config: config).import(start_date: start_date, end_date: end_date)
+    Importers::Twilio::Importer.new(
+      config: config,
+      twilio_lookup: double('Importers::Twilio::TwilioLookup', call: twilio_lookup_response)
+    ).import(start_date: start_date, end_date: end_date)
   end
 
   def then_the_daily_call_volume_for_twilio_should_be_saved
@@ -37,8 +89,38 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
     )
   end
 
+  def then_twilio_call_data_should_be_created # rubocop:disable Metrics/MethodLength
+    expect(TwilioCall.count).to eq(1)
+    expect(TwilioCall.first).to have_attributes(
+      twilio_lookup_response.slice(
+        'delivery_partner',
+        'location',
+        'location_postcode',
+        'booking_location',
+        'booking_location_postcode'
+      ).merge(
+        uid: 'CA7eb4d3924e3e73e9ef0dcad70b3b46fa',
+        inbound_number: '+441794840107',
+        outbound_number: '+441794840107',
+        call_duration: 12,
+        called_at: Time.zone.parse('2016-04-11 14:03:35'),
+        cost: -0.015,
+        outcome: 'forwarded',
+        location_uid: twilio_lookup_response['uid']
+      )
+    )
+  end
+
   def then_the_daily_call_volume_for_twilio_should_be_updated
     @daily_call.reload
     expect(@daily_call.twilio).to eq(1)
+  end
+
+  def the_call_record_has_not_been_changed
+    expect(TwilioCall.last).to have_attributes(call_params)
+  end
+
+  def twilio_lookup_response
+    @twilio_lookup_response || {}
   end
 end

--- a/spec/models/twilio_call_spec.rb
+++ b/spec/models/twilio_call_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe TwilioCall, type: :model do
+  it { is_expected.to validate_inclusion_of(:delivery_partner).in_array(Partners.face_to_face).allow_blank }
+  it { is_expected.to validate_inclusion_of(:outcome).in_array(%w(forwarded abandoned failed)) }
+  it { is_expected.to validate_presence_of(:uid) }
+  it { is_expected.to validate_presence_of(:inbound_number) }
+  it { is_expected.to validate_presence_of(:called_at) }
+end


### PR DESCRIPTION
In order to facilitate the PMB report we need to
additionally store the delivery partner, location 
and booking location for each call.

Postcode for location and booking location as also
stored to allow manual mapping to region as required.

Abandoned (calls < 10sec) and failed (inbound calls 
without a corresponding outbound call) are also being 
logged.