### PR TITLE
Twilio cost edge cases

### DIFF
--- a/db/migrate/20160822104923_increase_cost_scale.rb
+++ b/db/migrate/20160822104923_increase_cost_scale.rb
@@ -1,0 +1,5 @@
+class IncreaseCostScale < ActiveRecord::Migration
+  def change
+    change_column :twilio_calls, :cost, :decimal, precision: 10, scale: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160817132701) do
+ActiveRecord::Schema.define(version: 20160822104923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20160817132701) do
     t.string   "inbound_number"
     t.string   "outbound_number"
     t.integer  "call_duration"
-    t.decimal  "cost",                      precision: 10, scale: 4
+    t.decimal  "cost",                      precision: 10, scale: 5
     t.string   "outcome"
     t.string   "delivery_partner"
     t.string   "location_uid"

--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -51,7 +51,7 @@ module Importers
       end
 
       def cost
-        BigDecimal(@inbound_call.price) + (@outbound_call ? BigDecimal(@outbound_call.price) : 0)
+        BigDecimal(@inbound_call.price) + BigDecimal(@outbound_call&.price.to_s)
       end
 
       def outcome

--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -51,7 +51,7 @@ module Importers
       end
 
       def cost
-        BigDecimal(@inbound_call.price) + BigDecimal(@outbound_call&.price.to_s)
+        BigDecimal(@inbound_call.price.to_s) + BigDecimal(@outbound_call&.price.to_s)
       end
 
       def outcome

--- a/spec/lib/importers/twilio/call_record_spec.rb
+++ b/spec/lib/importers/twilio/call_record_spec.rb
@@ -50,4 +50,33 @@ RSpec.describe Importers::Twilio::CallRecord, :vcr do
       double(:call, params.merge(overrides)).as_null_object
     end
   end
+
+  describe '#cost' do
+    subject { described_class.new([inbound_call, outbound_call], {}) }
+    let(:inbound_call) { double(:inbound, price: '-0.00750') }
+
+    context 'when an outbound exists' do
+      let(:outbound_call) { double(:outbound, price: '-0.00375') }
+
+      it 'sums the outbound and inbound costs' do
+        expect(subject.cost).to eq(BigDecimal.new('-0.01125'))
+      end
+    end
+
+    context 'when no outbound call exists' do
+      let(:outbound_call) { nil }
+
+      it 'takes the inbound call cost only' do
+        expect(subject.cost).to eq(BigDecimal.new('-0.00750'))
+      end
+    end
+
+    context 'when an outbound call has no price (when the duration is 0)' do
+      let(:outbound_call) { double(:outbound, price: nil) }
+
+      it 'takes the inbound call cost only' do
+        expect(subject.cost).to eq(BigDecimal.new('-0.00750'))
+      end
+    end
+  end
 end

--- a/spec/models/twilio_call_spec.rb
+++ b/spec/models/twilio_call_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe TwilioCall, type: :model do
   it { is_expected.to validate_presence_of(:uid) }
   it { is_expected.to validate_presence_of(:inbound_number) }
   it { is_expected.to validate_presence_of(:called_at) }
+
+  it { is_expected.to have_db_column(:cost).with_options(scale: 5) }
 end


### PR DESCRIPTION
Increase scale on twilio cost DB field to ensure that we can accurately store the data retrieved from twilio.
Handle an edge case related to calls that exist with a duration of 0 being given a price of nil.