### PR TITLE
Display and export breakdown of Twilio calls

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,17 @@ class ReportsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        render csv: DailyCallVolumeCsv.new(@call_volumes.results), filename: 'call_volume.csv'
+        render csv: DailyCallVolumeCsv.new(@call_volumes.results), filename: 'daily_call_volume.csv'
+      end
+    end
+  end
+
+  def twilio_calls
+    @call_volumes = CallVolumes.new(date_params(:call_volumes))
+
+    respond_to do |format|
+      format.csv do
+        render csv: TwilioCallsCsv.new(@call_volumes.twilio_calls), filename: 'twilio_calls.csv'
       end
     end
   end

--- a/app/models/twilio_call.rb
+++ b/app/models/twilio_call.rb
@@ -1,7 +1,23 @@
 class TwilioCall < ActiveRecord::Base
+  OUTCOMES = [
+    FORWARDED = 'forwarded'.freeze,
+    ABANDONED = 'abandoned'.freeze,
+    FAILED = 'failed'.freeze
+  ].freeze
+
   validates :uid, :inbound_number, :called_at,
             presence: true
   validates :outcome,
-            inclusion: %w(forwarded abandoned failed)
+            inclusion: OUTCOMES
   validates :delivery_partner, inclusion: { in: Partners.face_to_face, allow_blank: true }
+
+  scope :forwarded, -> { where(outcome: TwilioCall::FORWARDED) }
+  scope :for_period, -> (period) { where('date(called_at) BETWEEN ? AND ?', period.first, period.last) }
+  scope :group_by_date, -> { group('date(called_at)').select('date(called_at)') }
+
+  def self.count_by_partner
+    group(:delivery_partner)
+      .select(:delivery_partner, 'count(twilio_calls.id) as count')
+      .order('')
+  end
 end

--- a/app/services/daily_call_volume_csv.rb
+++ b/app/services/daily_call_volume_csv.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class DailyCallVolumeCsv < CsvGenerator
   def attributes
-    %w(date twilio contact_centre).freeze
+    %w(date contact_centre twilio twilio_cas twilio_cita twilio_nicab twilio_unknown).freeze
   end
 end

--- a/app/services/twilio_calls_csv.rb
+++ b/app/services/twilio_calls_csv.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class TwilioCallsCsv < CsvGenerator
+  def attributes # rubocop: disable Metrics/MethodLength
+    %w(
+      called_at
+      outcome
+      call_duration
+      cost
+      inbound_number
+      outbound_number
+      location_uid
+      location
+      location_postcode
+      booking_location
+      booking_location_postcode
+      delivery_partner
+    ).freeze
+  end
+
+  def called_at_formatter(value)
+    value&.strftime('%Y-%m-%d %H:%M:%S')
+  end
+end

--- a/app/view_models/call_volume.rb
+++ b/app/view_models/call_volume.rb
@@ -1,0 +1,66 @@
+class CallVolume
+  def self.by_day(daily_call_volumes:, twilio_call_volumes:, period:)
+    daily_calls_by_date = daily_call_volumes.group_by(&:date)
+    twilio_calls_by_date = twilio_call_volumes.group_by_date.group_by(&:date)
+
+    period.map do |date|
+      new(
+        date: date,
+        daily_call_volumes: daily_calls_by_date.fetch(date, []),
+        twilio_call_volumes: twilio_calls_by_date.fetch(date, [])
+      )
+    end
+  end
+
+  attr_reader :date
+
+  def initialize(daily_call_volumes:, twilio_call_volumes:, date: nil)
+    @date = date
+    @daily_call_volumes = daily_call_volumes
+    @twilio_call_volumes = twilio_call_volumes
+  end
+
+  def contact_centre
+    @daily_call_volumes.sum(&:contact_centre)
+  end
+
+  def twilio
+    @daily_call_volumes.sum(&:twilio)
+  end
+
+  def twilio_cas
+    twilio_for(Partners::CAS)
+  end
+
+  def twilio_cita
+    twilio_for(Partners::CITA)
+  end
+
+  def twilio_nicab
+    twilio_for(Partners::NICAB)
+  end
+
+  def twilio_unknown
+    twilio_for(nil)
+  end
+
+  def attributes
+    {
+      'date' => date,
+      'contact_centre' => contact_centre,
+      'twilio' => twilio,
+      'twilio_cas' => twilio_cas,
+      'twilio_cita' => twilio_cita,
+      'twilio_nicab' => twilio_nicab,
+      'twilio_unknown' => twilio_unknown
+    }
+  end
+
+  private
+
+  def twilio_for(partner)
+    @twilio_call_volumes
+      .select { |twilio_call_volume| twilio_call_volume.delivery_partner == partner }
+      .sum(&:count)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= link_to 'Appointments', appointment_summaries_path %>
   </li>
   <li>
-    <%= link_to 'Call volumes', call_volumes_path %>
+    <%= link_to 'Call volumes', reports_call_volumes_path %>
   </li>
   <li>
     <%= link_to 'Satisfaction', reports_satisfaction_summary_path %>

--- a/app/views/reports/call_volumes.html.erb
+++ b/app/views/reports/call_volumes.html.erb
@@ -6,7 +6,7 @@
 <div class="row">
   <div class="col-md-12">
     <div class="well">
-      <%= form_for @call_volumes, url: call_volumes_path, method: :get, html: { class: 'inline form-inline' } do |f| %>
+      <%= form_for @call_volumes, url: reports_call_volumes_path, method: :get, html: { class: 'inline form-inline' } do |f| %>
         <div class="form-group">
           <%= f.label :start_date, 'From', class: 'inline' %>
           <%= f.text_field :start_date, type: :date, class: 'form-control t-start-date', placeholder: 'dd/mm/yyyy' %>
@@ -18,10 +18,16 @@
         <%= f.submit 'Search', class: 'btn btn-default t-search' %>
       <% end %>
 
-      <%= form_for @call_volumes, url: call_volumes_path(format: :csv), method: :get, html: { class: 'inline form-inline' } do |f| %>
+      <%= form_for @call_volumes, url: reports_call_volumes_path(format: :csv), method: :get, html: { class: 'inline form-inline' } do |f| %>
         <%= f.hidden_field :start_date %>
         <%= f.hidden_field :end_date %>
         <%= f.submit 'Export CSV', class: 'btn btn-default t-export-csv' %>
+      <% end %>
+
+      <%= form_for @call_volumes, url: reports_twilio_calls_path(format: :csv), method: :get, html: { class: 'inline form-inline' } do |f| %>
+        <%= f.hidden_field :start_date %>
+        <%= f.hidden_field :end_date %>
+        <%= f.submit 'Export Twilio Calls CSV', class: 'btn btn-default t-export-twilio-calls-csv' %>
       <% end %>
     </div>
     </div>
@@ -34,8 +40,18 @@
         <tr>
           <th>Date</th>
           <th>Day</th>
-          <th>Twilio call volume</th>
-          <th>Contact centre call volume</th>
+          <th>Contact centre</th>
+          <th colspan="5">Twilio</th>
+        </tr>
+        <tr>
+          <th></th>
+          <th></th>
+          <th>Total</th>
+          <th>Total</th>
+          <th>CAS</th>
+          <th>CITA</th>
+          <th>NICAB</th>
+          <th>Unknown</th>
         </tr>
       </thead>
       <tbody>
@@ -43,8 +59,12 @@
           <tr class="t-call-day">
             <td class="t-call-date"><%= daily_call_volume.date.to_s(:govuk_date) %></td>
             <td><%= daily_call_volume.date.strftime('%a') %></td>
-            <td class="t-twilio-calls"><%= daily_call_volume.twilio %></td>
             <td class="t-contact-centre-calls"><%= daily_call_volume.contact_centre %></td>
+            <td class="t-twilio-calls"><%= daily_call_volume.twilio %></td>
+            <td><%= daily_call_volume.twilio_cas %></td>
+            <td><%= daily_call_volume.twilio_cita %></td>
+            <td><%= daily_call_volume.twilio_nicab %></td>
+            <td><%= daily_call_volume.twilio_unknown %></td>
           </tr>
         <% end %>
       </tbody>
@@ -52,8 +72,12 @@
         <tr>
           <td>Total</td>
           <td>&nbsp;</td>
-          <td class="t-total-twilio-calls"><%= @call_volumes.total_calls(:twilio) %></td>
-          <td class="t-total-contact-centre-calls"><%= @call_volumes.total_calls(:contact_centre) %></td>
+          <td class="t-total-contact-centre-calls"><%= number_with_delimiter @call_volumes.total_calls.contact_centre %></td>
+          <td class="t-total-twilio-calls"><%= number_with_delimiter @call_volumes.total_calls.twilio %></td>
+          <td><%= number_with_delimiter @call_volumes.total_calls.twilio_cas %></td>
+          <td><%= number_with_delimiter @call_volumes.total_calls.twilio_cita %></td>
+          <td><%= number_with_delimiter @call_volumes.total_calls.twilio_nicab %></td>
+          <td><%= number_with_delimiter @call_volumes.total_calls.twilio_unknown %></td>
         </tr>
       </tfoot>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  get 'reports/call_volumes', to: 'reports#call_volumes', as: :call_volumes
+  get 'reports/call_volumes'
+  get 'reports/twilio_calls'
   get 'reports/where_did_you_hear'
   get 'reports/where_did_you_hear_summary'
   get 'reports/satisfaction_summary'

--- a/features/call_volumes_report.feature
+++ b/features/call_volumes_report.feature
@@ -19,9 +19,16 @@ Feature: Calls via the website
     Then the total number of calls for the contact centre within the date range is returned
     And a day-by-by breakdown for the contact centre within the date range is returned
 
-  Scenario: export calls to csv
+  Scenario: Export daily call volumes to CSV
     Given I am logged in as a Pension Wise data analyst
     When I visit the call volume report
     And I enter a valid date range
     And I export the results to CSV
+    Then I am prompted to download a CSV
+
+  Scenario: Export twilio calls to CSV
+    Given I am logged in as a Pension Wise data analyst
+    When I visit the call volume report
+    And I enter a valid date range
+    And I export the twilio calls to CSV
     Then I am prompted to download a CSV

--- a/features/pages/call_volumes_report_page.rb
+++ b/features/pages/call_volumes_report_page.rb
@@ -5,6 +5,7 @@ class CallVolumesReportPage < SitePrism::Page
   element :end_date, '.t-end-date'
   element :search, '.t-search'
   element :export_csv, '.t-export-csv'
+  element :export_twilio_calls_csv, '.t-export-twilio-calls-csv'
 
   element :total_twilio_calls, '.t-total-twilio-calls'
   element :total_contact_centre_calls, '.t-total-contact-centre-calls'

--- a/features/step_definitions/call_volumes_report_steps.rb
+++ b/features/step_definitions/call_volumes_report_steps.rb
@@ -36,12 +36,18 @@ Then(/^a day-by-by breakdown for (Twilio|the contact centre) within the date ran
 end
 
 When(/^I export the results to CSV$/) do
+  @filename = 'daily_call_volume.csv'
   @page.export_csv.click
+end
+
+When(/^I export the twilio calls to CSV$/) do
+  @filename = 'twilio_calls.csv'
+  @page.export_twilio_calls_csv.click
 end
 
 Then(/^I am prompted to download a CSV$/) do
   expect(page.response_headers).to include(
-    'Content-Disposition' => 'attachment; filename=call_volume.csv',
+    'Content-Disposition' => "attachment; filename=#{@filename}",
     'Content-Type'        => 'text/csv'
   )
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,6 +21,22 @@ FactoryGirl.define do
     satisfaction { rand(4).to_i }
   end
 
+  factory :twilio_call do
+    uid { SecureRandom.uuid }
+    called_at { Time.zone.now }
+    cost { BigDecimal('-0.01235') }
+    call_duration 45
+    inbound_number '+44111111111'
+    outbound_number '+44222222222'
+    outcome TwilioCall::FORWARDED
+    delivery_partner { (Partners.face_to_face + [nil]).sample }
+    location_uid { SecureRandom.uuid }
+    location 'location'
+    location_postcode 'LP12 3AA'
+    booking_location 'booking_location'
+    booking_location_postcode 'BLP12 3AA'
+  end
+
   factory :where_did_you_hear do
     given_at { Time.zone.now }
     delivery_partner { Partners.callable_delivery_partners.sample }

--- a/spec/services/daily_call_volume_csv_spec.rb
+++ b/spec/services/daily_call_volume_csv_spec.rb
@@ -5,25 +5,47 @@ RSpec.describe DailyCallVolumeCsv do
   let(:separator) { ',' }
 
   describe '#csv' do
-    subject { described_class.new(DailyCallVolume.new).call.lines }
+    let(:call_volumes) { CallVolume.new(date: Time.zone.today, daily_call_volumes: [], twilio_call_volumes: []) }
+    subject { described_class.new(call_volumes).call.lines }
 
     it 'generates headings' do
       expect(subject.first.chomp.split(separator)).to match_array(
         %w(
           date
-          twilio
           contact_centre
+          twilio
+          twilio_cas
+          twilio_cita
+          twilio_nicab
+          twilio_unknown
         )
       )
     end
 
     context 'data row are correct generated' do
       let(:daily_call_volumes) { [DailyCallVolume.new(date: Time.zone.today, contact_centre: 50, twilio: 100)] }
+      let(:twilio_call_volumes) do
+        [
+          double(delivery_partner: Partners::CAS, count: 10),
+          double(delivery_partner: Partners::CITA, count: 80),
+          double(delivery_partner: Partners::NICAB, count: 4),
+          double(delivery_partner: nil, count: 6)
+        ]
+      end
+      let(:call_volumes) do
+        [
+          CallVolume.new(
+            date: Time.zone.today,
+            daily_call_volumes: daily_call_volumes,
+            twilio_call_volumes: twilio_call_volumes
+          )
+        ]
+      end
 
-      subject { described_class.new(daily_call_volumes).call.lines }
+      subject { described_class.new(call_volumes).call.lines }
 
       it 'generates correctly mapped rows' do
-        expect(subject).to include("#{Time.zone.today},100,50\n")
+        expect(subject).to include("#{Time.zone.today},50,100,10,80,4,6\n")
       end
     end
   end

--- a/spec/services/twilio_calls_csv_spec.rb
+++ b/spec/services/twilio_calls_csv_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TwilioCallsCsv do
+  let(:separator) { ',' }
+
+  describe '#csv' do
+    subject { described_class.new(TwilioCall.new).call.lines }
+
+    it 'generates headings' do
+      expect(subject.first.chomp.split(separator, -1)).to match_array(
+        %w(
+          called_at
+          outcome
+          call_duration
+          cost
+          inbound_number
+          outbound_number
+          location_uid
+          location
+          location_postcode
+          booking_location
+          booking_location_postcode
+          delivery_partner
+        )
+      )
+    end
+
+    context 'data row are correct generated' do
+      let(:record) { build_stubbed(:twilio_call) }
+      subject { described_class.new(record).call.lines }
+
+      it 'generates correctly mapped rows' do
+        expect(subject.last.chomp.split(separator, -1)).to eq(
+          [
+            record.called_at.strftime('%Y-%m-%d %H:%M:%S'),
+            record.outcome,
+            record.call_duration.to_s,
+            record.cost.to_s,
+            record.inbound_number,
+            record.outbound_number,
+            record.location_uid,
+            record.location,
+            record.location_postcode,
+            record.booking_location,
+            record.booking_location_postcode,
+            record.delivery_partner
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow twilio data to be reported at a PMB report 
level (DP breakdown)

- Add breakdown by DP to report view and export.
- Add export of raw calls with all stored data fields