### PR TITLE
Remove `frozen_string_literal` from files

### DIFF
--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 require 'csv'
 
 class CsvGenerator

--- a/app/services/daily_call_volume_csv.rb
+++ b/app/services/daily_call_volume_csv.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class DailyCallVolumeCsv < CsvGenerator
   def attributes
     %w(date contact_centre twilio twilio_cas twilio_cita twilio_nicab twilio_unknown).freeze

--- a/app/services/satisfaction_csv.rb
+++ b/app/services/satisfaction_csv.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class SatisfactionCsv < CsvGenerator
   def attributes
     %w(

--- a/app/services/satisfaction_summary_csv.rb
+++ b/app/services/satisfaction_summary_csv.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class SatisfactionSummaryCsv < CsvGenerator
   def attributes
     %w(

--- a/app/services/twilio_calls_csv.rb
+++ b/app/services/twilio_calls_csv.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class TwilioCallsCsv < CsvGenerator
   def attributes # rubocop: disable Metrics/MethodLength
     %w(

--- a/app/services/where_did_you_hear_csv.rb
+++ b/app/services/where_did_you_hear_csv.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class WhereDidYouHearCsv < CsvGenerator
   def attributes
     %w(

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 ActionController::Renderers.add :csv do |object, options|
   filename = options.fetch(:filename, 'data.csv')
   filename << '.csv' unless filename =~ /\.csv$/

--- a/lib/importers/google/satisfaction/call_record.rb
+++ b/lib/importers/google/satisfaction/call_record.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 module Importers
   module Google
     module Satisfaction

--- a/spec/services/daily_call_volume_csv_spec.rb
+++ b/spec/services/daily_call_volume_csv_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe DailyCallVolumeCsv do

--- a/spec/services/twilio_calls_csv_spec.rb
+++ b/spec/services/twilio_calls_csv_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe TwilioCallsCsv do


### PR DESCRIPTION
This was added to satisfy a rubocop rule which has since been disabled.
The comment has been removed from files where it does not affect the code.

i.e. no unfrozen string literals exist.