### PR TITLE
Tp call outcomes

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,16 @@ class ReportsController < ApplicationController
     render csv: CostBreakdownRawCsv.new(costs_report.raw), filename: 'cost_breakdown_raw.csv'
   end
 
+  def tp_calls
+    @call_volumes = CallVolumes.new(date_params(:call_volumes))
+
+    respond_to do |format|
+      format.csv do
+        render csv: TpCallsCsv.new(@call_volumes.tp_calls), filename: 'tp_calls.csv'
+      end
+    end
+  end
+
   def twilio_calls
     @call_volumes = CallVolumes.new(date_params(:call_volumes))
 

--- a/app/forms/call_volumes.rb
+++ b/app/forms/call_volumes.rb
@@ -27,6 +27,10 @@ class CallVolumes
     TwilioCall.for_period(period)
   end
 
+  def tp_calls
+    TpCall.for_period(period)
+  end
+
   private
 
   def twilio_calls_forwarded_by_partner

--- a/app/models/tp_call.rb
+++ b/app/models/tp_call.rb
@@ -1,0 +1,2 @@
+class TpCall < ActiveRecord::Base
+end

--- a/app/models/tp_call.rb
+++ b/app/models/tp_call.rb
@@ -1,2 +1,5 @@
 class TpCall < ActiveRecord::Base
+  validates :uid, :outcome, :called_at, presence: true
+
+  scope :for_period, -> (period) { where('date(called_at) BETWEEN ? AND ?', period.first, period.last) }
 end

--- a/app/services/tp_calls_csv.rb
+++ b/app/services/tp_calls_csv.rb
@@ -1,0 +1,16 @@
+class TpCallsCsv < CsvGenerator
+  def attributes
+    %w(
+      uid
+      called_at
+      outcome
+      call_duration
+      third_party_referring
+      pension_provider
+    ).freeze
+  end
+
+  def called_at_formatter(value)
+    value&.strftime('%Y-%m-%d %H:%M:%S')
+  end
+end

--- a/app/views/reports/call_volumes.html.erb
+++ b/app/views/reports/call_volumes.html.erb
@@ -29,6 +29,12 @@
         <%= f.hidden_field :end_date %>
         <%= f.submit 'Export twilio calls CSV', class: 'btn btn-default t-export-twilio-calls-csv' %>
       <% end %>
+
+      <%= form_for @call_volumes, url: reports_tp_calls_path(format: :csv), method: :get, html: { class: 'inline form-inline' } do |f| %>
+        <%= f.hidden_field :start_date %>
+        <%= f.hidden_field :end_date %>
+        <%= f.submit 'Export TP calls CSV', class: 'btn btn-default t-export-tp-calls-csv' %>
+      <% end %>
     </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
   get 'reports/call_volumes'
+  get 'reports/tp_calls'
   get 'reports/twilio_calls'
   get 'reports/where_did_you_hear'
   get 'reports/where_did_you_hear_summary'

--- a/db/migrate/20161013122933_create_tp_calls.rb
+++ b/db/migrate/20161013122933_create_tp_calls.rb
@@ -1,0 +1,14 @@
+class CreateTpCalls < ActiveRecord::Migration
+  def change
+    create_table :tp_calls do |t|
+      t.string :uid
+      t.datetime :called_at
+      t.string :outcome
+      t.string :third_party_referring
+      t.string :pension_provider
+      t.integer :call_duration
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160929015240) do
+ActiveRecord::Schema.define(version: 20161013122933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,17 @@ ActiveRecord::Schema.define(version: 20160929015240) do
     t.string   "location",         default: "", null: false
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+  end
+
+  create_table "tp_calls", force: :cascade do |t|
+    t.string   "uid"
+    t.datetime "called_at"
+    t.string   "outcome"
+    t.string   "third_party_referring"
+    t.string   "pension_provider"
+    t.integer  "call_duration"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
   create_table "twilio_calls", force: :cascade do |t|

--- a/lib/importers/tp/call_record.rb
+++ b/lib/importers/tp/call_record.rb
@@ -5,7 +5,7 @@ module Importers
         @row = row
       end
 
-      def params
+      def wdyh_params
         {
           uid: uid,
           given_at: given_at,
@@ -18,7 +18,34 @@ module Importers
         }
       end
 
+      def call_params
+        {
+          uid: uid,
+          called_at: given_at,
+          outcome: outcome,
+          third_party_referring: third_party_referring,
+          pension_provider: referring_pension_provider,
+          call_duration: call_duration
+        }
+      end
+
       def uid
+        @row[16]&.value || old_uid
+      end
+
+      def third_party_referring
+        @row[17]&.value.to_s
+      end
+
+      def referring_pension_provider
+        '' # waiting for TP to add data column to output
+      end
+
+      def call_duration
+        @row[4]&.value.to_f.round
+      end
+
+      def old_uid
         md5 = Digest::MD5.new
         raw_uid.each { |value| md5 << value }
         md5.hexdigest

--- a/spec/features/import_tp_data_spec.rb
+++ b/spec/features/import_tp_data_spec.rb
@@ -8,6 +8,11 @@ RSpec.feature 'Importing tp data' do
     then_the_daily_call_volume_for_tp_should_be_saved
   end
 
+  scenario 'Storing tp call record' do
+    when_i_import_tp_data
+    then_the_call_records_for_tp_should_be_saved
+  end
+
   scenario 'Updating daily call volumes' do
     given_old_daily_call_volumes_exists
     when_i_import_tp_data
@@ -74,6 +79,17 @@ RSpec.feature 'Importing tp data' do
       date: Date.new(2016, 5, 4),
       twilio: 0,
       contact_centre: 3
+    )
+  end
+
+  def then_the_call_records_for_tp_should_be_saved
+    expect(TpCall.first).to have_attributes(
+      uid: '0332b7444d0608369a7af36e5a7996d0',
+      called_at: Time.zone.parse('2016-05-04 08:25:49'),
+      outcome: 'Customer Not Eligible - Pension Type',
+      third_party_referring: '',
+      pension_provider: '',
+      call_duration: 143
     )
   end
 


### PR DESCRIPTION
Store outcome data for TP calls.

This has been stored in a new table meaning we now have three tables for 
call data:

* DailyCAllVolume
* TwilioCall
* TpCall

while this is not ideal it does give us the functionality we want as the two datasets (TP/Twilio) have very little overlap in data and functionality.