### PR TITLE
Fix satisfaction report bug

### DIFF
--- a/app/services/satisfaction_summary.rb
+++ b/app/services/satisfaction_summary.rb
@@ -20,7 +20,7 @@ class SatisfactionSummary
   def rows
     partners = build_partners(
       satisfaction_count: @scope.group(:delivery_partner, :satisfaction).count,
-      completion_count: AppointmentSummary.where(year_month_id: @year_month.id)
+      completion_count: AppointmentSummary.non_web.where(year_month_id: @year_month.id)
     )
 
     columns = partners.merge(

--- a/features/step_definitions/satisfaction_report_steps.rb
+++ b/features/step_definitions/satisfaction_report_steps.rb
@@ -1,5 +1,8 @@
 Given(/^there are existing satisfaction records$/) do
-  create_list(:satisfaction, 2)
+  year_month = YearMonth.build(1.month.ago)
+  create_list(:satisfaction, 2, given_at: 1.month.ago)
+  create(:appointment_summary, year_month: year_month)
+  create(:appointment_summary, year_month: year_month, delivery_partner: Partners::WEB_VISITS)
 end
 
 When(/^I visit the satisfaction report$/) do


### PR DESCRIPTION
Bug created by store web sessions in appointment
summary table (transactions). This makes sense for
the costing report but broke the satisfaction report.

This fix pre filters the appointment summary data
to the valid set before applying completion numbers.