### PR TITLE
Store opening hours on Twilio Call

### DIFF
--- a/app/services/twilio_calls_csv.rb
+++ b/app/services/twilio_calls_csv.rb
@@ -13,10 +13,16 @@ class TwilioCallsCsv < CsvGenerator
       booking_location
       booking_location_postcode
       delivery_partner
+      hours
     ).freeze
   end
 
   def called_at_formatter(value)
     value&.strftime('%Y-%m-%d %H:%M:%S')
+  end
+
+  def hours_formatter(value)
+    return unless value.present?
+    value.gsub(/,/, ' -').gsub(/[\r\n]+/, '; ')
   end
 end

--- a/db/migrate/20161019151220_add_hours_to_twilio_calls.rb
+++ b/db/migrate/20161019151220_add_hours_to_twilio_calls.rb
@@ -1,0 +1,11 @@
+class AddHoursToTwilioCalls < ActiveRecord::Migration
+  def change
+    add_column :twilio_calls, :hours, :string, limit: 500
+
+    puts <<~AFTER_MIGRATION
+      Run to populate 'hours' on existing records.
+
+      rake data_migration:populate_hours_on_twilio_calls
+    AFTER_MIGRATION
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161013122933) do
+ActiveRecord::Schema.define(version: 20161019151220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 20161013122933) do
     t.string   "inbound_number"
     t.string   "outbound_number"
     t.integer  "call_duration"
-    t.decimal  "cost",                      precision: 10, scale: 5
+    t.decimal  "cost",                                  precision: 10, scale: 5
     t.string   "outcome"
     t.string   "delivery_partner"
     t.string   "location_uid"
@@ -143,8 +143,9 @@ ActiveRecord::Schema.define(version: 20161013122933) do
     t.string   "location_postcode"
     t.string   "booking_location"
     t.string   "booking_location_postcode"
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
+    t.datetime "created_at",                                                     null: false
+    t.datetime "updated_at",                                                     null: false
+    t.string   "hours",                     limit: 500
   end
 
   create_table "uploaded_files", force: :cascade do |t|

--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -17,7 +17,8 @@ module Importers
           location: @location_details['location'],
           location_postcode: @location_details['location_postcode'],
           booking_location: @location_details['booking_location'],
-          booking_location_postcode: @location_details['booking_location_postcode']
+          booking_location_postcode: @location_details['booking_location_postcode'],
+          hours: @location_details['hours']
         }
       end
 

--- a/lib/importers/twilio/twilio_lookup.rb
+++ b/lib/importers/twilio/twilio_lookup.rb
@@ -4,17 +4,15 @@ module Importers
   module Twilio
     class TwilioLookup
       def initialize(config: Rails.configuration.x.locations)
-        @config = config
+        @twilio_numbers = LocationApi.new(config: config).all['twilio_numbers']
       end
 
       def call(twilio_number)
-        twilio_numbers.fetch(twilio_number, {})
+        @twilio_numbers.fetch(twilio_number, {})
       end
 
-      private
-
-      def twilio_numbers
-        @twilio_numbers ||= LocationApi.new(config: @config).all['twilio_numbers']
+      def all
+        @twilio_numbers
       end
     end
   end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,0 +1,12 @@
+namespace :data_migration do
+  desc 'Populate hours on twilio_calls'
+  task populate_hours_on_twilio_calls: :environment do
+    require 'importers'
+
+    twilio_lookups = Importers::Twilio::TwilioLookup.new.all
+
+    twilio_lookups.each do |inbound_number, details|
+      TwilioCall.where(inbound_number: inbound_number, hours: nil).update_all(hours: details['hours'])
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -46,6 +46,7 @@ FactoryGirl.define do
     location_postcode 'LP12 3AA'
     booking_location 'booking_location'
     booking_location_postcode 'BLP12 3AA'
+    hours "Monday to Thursday, 9:30am to 5pm\nFriday, 9:30am to 4:30pm"
   end
 
   factory :where_did_you_hear do

--- a/spec/jobs/import_twilio_data_job_spec.rb
+++ b/spec/jobs/import_twilio_data_job_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe ImportTwilioData, type: :job do
   end
 
   it 'performs the job - with correctly parsed date value' do
-    expect_any_instance_of(Importers::Twilio::Importer).to receive(:import).with(
+    importer = double
+    allow(Importers::Twilio::Importer).to receive(:new).and_return(importer)
+    expect(importer).to receive(:import).with(
       start_date: date,
       end_date: date
     )

--- a/spec/services/twilio_calls_csv_spec.rb
+++ b/spec/services/twilio_calls_csv_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe TwilioCallsCsv do
           booking_location
           booking_location_postcode
           delivery_partner
+          hours
         )
       )
     end
@@ -43,7 +44,8 @@ RSpec.describe TwilioCallsCsv do
             record.location_postcode,
             record.booking_location,
             record.booking_location_postcode,
-            record.delivery_partner.to_s
+            record.delivery_partner.to_s,
+            'Monday to Thursday - 9:30am to 5pm; Friday - 9:30am to 4:30pm'
           ]
         )
       end


### PR DESCRIPTION
This is stored on the object so that changes
over time can be ignored, as the object will have
the opening hours from the date it was imported
(move forward).

__This change was requested from the Analytics team.__