### PR TITLE
Add outbound call outcome to twilio calls

### DIFF
--- a/app/services/twilio_calls_csv.rb
+++ b/app/services/twilio_calls_csv.rb
@@ -3,6 +3,7 @@ class TwilioCallsCsv < CsvGenerator
     %w(
       called_at
       outcome
+      outbound_call_outcome
       call_duration
       cost
       inbound_number

--- a/db/migrate/20161102150908_add_outbound_call_outcome_to_twilio_calls.rb
+++ b/db/migrate/20161102150908_add_outbound_call_outcome_to_twilio_calls.rb
@@ -1,0 +1,5 @@
+class AddOutboundCallOutcomeToTwilioCalls < ActiveRecord::Migration
+  def change
+    add_column :twilio_calls, :outbound_call_outcome, :string, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161025094246) do
+ActiveRecord::Schema.define(version: 20161102150908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,9 +144,10 @@ ActiveRecord::Schema.define(version: 20161025094246) do
     t.string   "location_postcode"
     t.string   "booking_location"
     t.string   "booking_location_postcode"
-    t.datetime "created_at",                                                     null: false
-    t.datetime "updated_at",                                                     null: false
+    t.datetime "created_at",                                                                  null: false
+    t.datetime "updated_at",                                                                  null: false
     t.string   "hours",                     limit: 500
+    t.string   "outbound_call_outcome",                                          default: "", null: false
   end
 
   create_table "uploaded_files", force: :cascade do |t|

--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -12,6 +12,7 @@ module Importers
           call_duration: outbound_call_duration,
           cost: cost,
           outcome: outcome,
+          outbound_call_outcome: outbound_call_outcome,
           delivery_partner: @location_details['delivery_partner'],
           location_uid: @location_details['uid'],
           location: @location_details['location'],
@@ -58,6 +59,10 @@ module Importers
       def outcome
         return 'failed' unless @outbound_call
         valid? ? 'forwarded' : 'abandoned'
+      end
+
+      def outbound_call_outcome
+        @outbound_call&.status || ''
       end
 
       def valid?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,6 +40,7 @@ FactoryGirl.define do
     inbound_number '+44111111111'
     outbound_number '+44222222222'
     outcome TwilioCall::FORWARDED
+    outbound_call_outcome 'completed'
     delivery_partner { (Partners.face_to_face + [nil]).sample }
     location_uid { SecureRandom.uuid }
     location 'location'

--- a/spec/features/import_twilio_call_data_spec.rb
+++ b/spec/features/import_twilio_call_data_spec.rb
@@ -106,6 +106,7 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
         called_at: Time.zone.parse('2016-04-11 14:03:35'),
         cost: -0.015,
         outcome: 'forwarded',
+        outbound_call_outcome: 'completed',
         location_uid: twilio_lookup_response['uid']
       )
     )

--- a/spec/services/twilio_calls_csv_spec.rb
+++ b/spec/services/twilio_calls_csv_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TwilioCallsCsv do
         %w(
           called_at
           outcome
+          outbound_call_outcome
           call_duration
           cost
           inbound_number
@@ -35,6 +36,7 @@ RSpec.describe TwilioCallsCsv do
           [
             record.called_at.strftime('%Y-%m-%d %H:%M:%S'),
             record.outcome,
+            record.outbound_call_outcome,
             record.call_duration.to_s,
             record.cost.to_s,
             record.inbound_number,


### PR DESCRIPTION
This will give more visibility to busy and unanswered
calls to CAB offices.

This fields can have the following values:

* <blank> - no call was made
* completed - the call was ended normally
* busy - line was busy
* no-answer - no one answered
* failed - the number was invalid