### PR TITLE
Update static data on TwilioCall during reimport

### DIFF
--- a/lib/importers/twilio/call_record.rb
+++ b/lib/importers/twilio/call_record.rb
@@ -4,7 +4,19 @@ module Importers
       MINIMUM_CALL_TIME = 10
       ANONYMOUS_NUMBER = '+266696687'.freeze
 
-      def params # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def params
+        static_params.merge(
+          delivery_partner: @location_details['delivery_partner'],
+          location_uid: @location_details['uid'],
+          location: @location_details['location'],
+          location_postcode: @location_details['location_postcode'],
+          booking_location: @location_details['booking_location'],
+          booking_location_postcode: @location_details['booking_location_postcode'],
+          hours: @location_details['hours']
+        )
+      end
+
+      def static_params # rubocop:disable Metrics/MethodLength
         {
           uid: uid,
           called_at: called_at,
@@ -14,14 +26,7 @@ module Importers
           call_duration: outbound_call_duration,
           cost: cost,
           outcome: outcome,
-          outbound_call_outcome: outbound_call_outcome,
-          delivery_partner: @location_details['delivery_partner'],
-          location_uid: @location_details['uid'],
-          location: @location_details['location'],
-          location_postcode: @location_details['location_postcode'],
-          booking_location: @location_details['booking_location'],
-          booking_location_postcode: @location_details['booking_location_postcode'],
-          hours: @location_details['hours']
+          outbound_call_outcome: outbound_call_outcome
         }
       end
 

--- a/lib/importers/twilio/saver.rb
+++ b/lib/importers/twilio/saver.rb
@@ -14,8 +14,11 @@ module Importers
 
       def save_calls!
         @calls.each do |call|
-          TwilioCall.find_by(uid: call.uid) ||
+          if twilio_call = TwilioCall.find_by(uid: call.uid)
+            twilio_call.update!(call.static_params)
+          else
             TwilioCall.create!(call.params)
+          end
         end
       end
 

--- a/spec/features/import_twilio_call_data_spec.rb
+++ b/spec/features/import_twilio_call_data_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
   scenario 'It does not update existsing call records' do
     given_a_call_record_exists
     when_i_import_twilio_data
-    the_call_record_has_not_been_changed
+    only_the_call_records_twilio_values_have_been_changed
   end
 
   def given_old_daily_call_volumes_exists
@@ -119,8 +119,12 @@ RSpec.feature 'Importing twilio call data', vcr: { cassette_name: 'twilio_single
     expect(@daily_call.twilio).to eq(1)
   end
 
-  def the_call_record_has_not_been_changed
-    expect(TwilioCall.last).to have_attributes(call_params)
+  def only_the_call_records_twilio_values_have_been_changed
+    twilio_data_fields = %i(inbound_number outbound_number caller_phone_number call_duration called_at cost outcome)
+    location_fields = %i(delivery_partner location_uid location location_postcode booking_location
+                         booking_location_postcode)
+    expect(TwilioCall.last).not_to have_attributes(call_params.slice(twilio_data_fields))
+    expect(TwilioCall.last).to have_attributes(call_params.slice(location_fields))
   end
 
   def twilio_lookup_response


### PR DESCRIPTION
This is required to allow population of new data fields
without deleting historical data. This is important
as location based data is a snap shot of the point
in time that it was imported.