### PR TITLE
Refactor the cost reporting to reduce DB calls

### DIFF
--- a/app/models/cost_item.rb
+++ b/app/models/cost_item.rb
@@ -8,6 +8,7 @@ class CostItem < ApplicationRecord
   validates :name, :cost_group, presence: true
   validates :delivery_partner, inclusion: { in: allowed_delivery_partners, allow_blank: true }
 
-  scope :current, -> { where(current: true) }
-  scope :during_months, ->(year_months) { includes(:costs).where(costs: { year_month_id: year_months }) }
+  scope :current, -> { reporting_includes.where(current: true) }
+  scope :during_months, ->(year_months) { reporting_includes.where(costs: { year_month_id: year_months }) }
+  scope :reporting_includes, -> { includes(costs: :year_month) }
 end

--- a/app/view_models/costs/item.rb
+++ b/app/view_models/costs/item.rb
@@ -9,8 +9,13 @@ module Costs
 
     def all
       @all ||= begin
+        grouped_costs = @cost_item.costs.group_by(&:year_month_id)
         @year_months.map do |year_month|
-          Costs::MonthItem.new(cost_item: @cost_item, year_month: year_month)
+          Costs::MonthItem.new(
+            cost_item: @cost_item,
+            year_month: year_month,
+            costs: grouped_costs.fetch(year_month.id, [])
+          )
         end
       end
     end

--- a/app/view_models/costs/month_item.rb
+++ b/app/view_models/costs/month_item.rb
@@ -4,34 +4,27 @@ module Costs
 
     delegate :id, to: :@cost_item, prefix: 'cost_item'
 
-    def initialize(cost_item:, year_month:)
+    def initialize(cost_item:, year_month:, costs:)
       @cost_item = cost_item
       @year_month = year_month
+
+      @data = costs.each_with_object(forecast: false, value: 0, count: 0) do |cost, data|
+        data[:value] += cost.value_delta
+        data[:forecast] = cost.forecast
+        data[:count] += 1
+      end
     end
 
     def count
-      data[:count]
+      @data[:count]
     end
 
     def value
-      data[:value]
+      @data[:value]
     end
 
     def forecast
-      data[:forecast]
-    end
-
-    private
-
-    def data
-      @data ||= begin
-        costs = Cost.for(@year_month).where(cost_item_id: @cost_item.id).order(:id)
-        costs.each_with_object(forecast: false, value: 0, count: 0) do |cost, data|
-          data[:value] += cost.value_delta
-          data[:forecast] = cost.forecast
-          data[:count] += 1
-        end
-      end
+      @data[:forecast]
     end
   end
 end

--- a/spec/view_models/costs/item_spec.rb
+++ b/spec/view_models/costs/item_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Costs::Item do
-  let(:previous_month) { create(:year_month, date: (Time.zone.today << 1)) }
-  let(:current_month) { create(:year_month) }
+  let(:previous_month) { build_stubbed(:year_month, date: (Time.zone.today << 1)) }
+  let(:current_month) { build_stubbed(:year_month) }
   let(:year_months) { [previous_month, current_month] }
-  let(:cost_item) { double('CostItem') }
+  let(:cost_item) { double('CostItem', costs: []) }
   subject { described_class.new(cost_item: cost_item, year_months: year_months) }
 
   context '#all' do

--- a/spec/view_models/costs/month_item_spec.rb
+++ b/spec/view_models/costs/month_item_spec.rb
@@ -1,23 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Costs::MonthItem do
-  let(:year_month) { create(:year_month) }
-  let(:cost_item) { create(:cost_item) }
-  subject { described_class.new(cost_item: cost_item, year_month: year_month) }
+  let(:year_month) { build_stubbed(:year_month) }
+  let(:cost_item) { build_stubbed(:cost_item) }
+  subject { described_class.new(cost_item: cost_item, year_month: year_month, costs: costs) }
 
   context '#value' do
     context 'when a single cost entry exists' do
+      let(:costs) { [build_stubbed(:cost, value_delta: 150)] }
+
       it 'returns the value of the cost item' do
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, value_delta: 150)
         expect(subject.value).to eq(150)
       end
     end
 
     context 'when a multiple cost entry exists' do
+      let(:costs) {
+        [
+          build_stubbed(:cost, value_delta: 150),
+          build_stubbed(:cost, value_delta: 150),
+          build_stubbed(:cost, value_delta: -100)
+        ]
+      }
+
       it 'returns the sum of the cost item' do
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, value_delta: 150)
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, value_delta: 150)
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, value_delta: -100)
         expect(subject.value).to eq(200)
       end
     end
@@ -25,16 +31,22 @@ RSpec.describe Costs::MonthItem do
 
   context '#forecast' do
     context 'when a single cost entry exists' do
+      let(:costs) { [build_stubbed(:cost, forecast: true)] }
+
       it 'returns the forecast flag of the cost item' do
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, forecast: true)
         expect(subject.forecast).to be_truthy
       end
     end
 
     context 'when a multiple cost entry exists' do
+      let(:costs) {
+        [
+          build_stubbed(:cost, forecast: true),
+          build_stubbed(:cost, forecast: false)
+        ]
+      }
+
       it 'returns the forecast flag from the last item (by ID)' do
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, forecast: true)
-        create(:cost, year_month_id: year_month.id, cost_item: cost_item, forecast: false)
         expect(subject.forecast).to be_falsey
       end
     end


### PR DESCRIPTION
It makes more sense to eager load the data and then
partition in code that make an extra database call
for each cost_item/month combination.