### PR TITLE
Fix bug with costs breakdown report when no twilio calls

### DIFF
--- a/app/view_models/cost_per_transaction.rb
+++ b/app/view_models/cost_per_transaction.rb
@@ -42,7 +42,7 @@ class CostPerTransaction
   def cost_by_delivery_partner
     @cost_by_delivery_partner ||= begin
       calls_by_partner = cost_scope.by_delivery_partner.sum(:value_delta)
-      CostByDeliveryPartner.new(calls_by_partner, year_month.value).call
+      CostByDeliveryPartner.new(calls_by_partner, year_month).call
     end
   end
 end

--- a/app/view_models/cost_per_transaction/cost_by_delivery_partner.rb
+++ b/app/view_models/cost_per_transaction/cost_by_delivery_partner.rb
@@ -1,8 +1,8 @@
 class CostPerTransaction
   class CostByDeliveryPartner
-    def initialize(cost_by_partner, formatted_month)
+    def initialize(cost_by_partner, year_month)
       @cost_by_partner = cost_by_partner
-      @formatted_month = formatted_month
+      @year_month = year_month
     end
 
     def call
@@ -16,7 +16,7 @@ class CostPerTransaction
     private
 
     def add_costs_by_partner(results, split_by, total_cost)
-      splitter = "CostPerTransaction::#{split_by.camelcase}".constantize.new(@formatted_month)
+      splitter = "CostPerTransaction::#{split_by.camelcase}".constantize.new(@year_month)
       splitter.call(total_cost).each do |partner, cost|
         results[partner] ||= 0
         results[partner] += cost


### PR DESCRIPTION
This bug presents when entering data for May 2015 as
twilio was only used from Aug 2015 onwards.

This fix uses calls volumes from the next month with any
calls if no calls exists for the given month.

An additionally fallback has been added in case future cost
data is entered. In this case it will split based on
call volumes from the previous month with call data.