### PR TITLE
Don't default time formatting

### DIFF
--- a/app/forms/where_did_you_hears.rb
+++ b/app/forms/where_did_you_hears.rb
@@ -6,7 +6,7 @@ class WhereDidYouHears
   def initialize(page:, start_date:, end_date:)
     @page       = page
     @start_date = normalise_date(start_date, 1.month.ago.to_date)
-    @end_date   = normalise_date(end_date, Time.zone.today)
+    @end_date   = normalise_date(end_date, Time.zone.now.to_date)
   end
 
   def results
@@ -26,6 +26,6 @@ class WhereDidYouHears
   end
 
   def normalise_date(date, default)
-    date.present? ? Time.zone.parse(date) : default
+    date.present? ? Date.parse(date) : default
   end
 end

--- a/app/services/cost_breakdown_raw_csv.rb
+++ b/app/services/cost_breakdown_raw_csv.rb
@@ -21,6 +21,10 @@ class CostBreakdownRawCsv < CsvGenerator
     value ? 'yes' : 'no'
   end
 
+  def created_at_formatter(value)
+    value.to_date
+  end
+
   class Row
     def initialize(record)
       @record = record

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,1 @@
-default = { default: '%Y-%m-%d' }
-Time::DATE_FORMATS.merge!(default)
-Date::DATE_FORMATS.merge!(default)
+Date::DATE_FORMATS[default: '%Y-%m-%d']

--- a/lib/importers/tp/call_record.rb
+++ b/lib/importers/tp/call_record.rb
@@ -53,7 +53,7 @@ module Importers
       end
 
       def raw_uid
-        @row.values[0..13].map { |cell| fix_number_formatting(cell&.value).to_s }
+        @row.values[0..13].map { |cell| format(cell&.value).to_s }
       end
 
       def date
@@ -89,12 +89,11 @@ module Importers
         date
       end
 
-      # fix bug for non decimal e numbers
-      # 500000e-6 should come out formatted as 0.5, however the RubyXL regexp does not recognise this as a number
-      # in some formats of the process.
-      def fix_number_formatting(value)
+      def format(value)
         if value.is_a?(String) && value =~ /\A\d+e[+-]\d+\z/
           value.to_f
+        elsif value.is_a?(DateTime)
+          value.to_date
         else
           value
         end

--- a/lib/twilio_numbers/phone_numbers.rb
+++ b/lib/twilio_numbers/phone_numbers.rb
@@ -21,7 +21,7 @@ module TwilioNumbers
         csv << headers
 
         @numbers.values.each do |phone_number|
-          csv << phone_number.get(headers)
+          csv << phone_number.get(headers).map { |v| v.is_a?(Time) ? v.to_date : v }
         end
       end
     end

--- a/spec/forms/where_did_you_hears_spec.rb
+++ b/spec/forms/where_did_you_hears_spec.rb
@@ -10,17 +10,6 @@ RSpec.describe WhereDidYouHears do
     end
   end
 
-  describe '#start_date and #end_date' do
-    context 'with a datetime, when presenting' do
-      it 'strips the time portion so the field can be bound to an HTML5 date picker' do
-        subject.start_date = subject.end_date = Time.zone.parse('2016-01-01 00:00:00 UTC')
-
-        expect(subject.start_date.to_s).to eq('2016-01-01')
-        expect(subject.end_date.to_s).to eq('2016-01-01')
-      end
-    end
-  end
-
   describe '#paginated_results' do
     let(:page_size_plus_one) { Kaminari.config.default_per_page + 1 }
 


### PR DESCRIPTION
This was a bad idea from the start and now causes problems with
exporting CSV data using blazer. Where we need to format timestamps
without the time portion we now do this explicitly.