### PR TITLE
Handle new mappings

### DIFF
--- a/app/models/code_lookup.rb
+++ b/app/models/code_lookup.rb
@@ -1,10 +1,21 @@
 class CodeLookup < ApplicationRecord
   class MissingMappingError < StandardError; end
 
+  CORRECTIONS = [
+    'online booking',
+    'Various',
+    'Age UK',
+    'Macmillan ',
+    'Friend',
+    'Leaflet in job centre'
+  ].freeze
+
   validates :from, presence: true, uniqueness: true
 
   def self.for(value:)
     return '' if value.blank?
+    return 'Other' if CORRECTIONS.include?(value)
+
     find_or_create_by!(from: value).to
   end
 

--- a/db/seeds/code_lookups.rb
+++ b/db/seeds/code_lookups.rb
@@ -29,6 +29,7 @@ end
   { from: 'A Pension Provider', to: 'A Pension Provider' },
   { from: 'Internet search', to: 'Internet search' },
   { from: 'The Government’s Gov.uk website', to: 'The Government’s Gov.uk website' },
+  { from: 'The Government’s GOV.UK website', to: 'The Government’s Gov.uk website' },
   { from: 'Radio advert', to: 'Radio advert' },
   { from: 'TV advert', to: 'TV advert' },
   { from: 'Other', to: 'Other' },

--- a/lib/importers/smart_survey/call_record.rb
+++ b/lib/importers/smart_survey/call_record.rb
@@ -3,25 +3,6 @@ require 'csv'
 module Importers
   module SmartSurvey
     class CallRecord
-      HEARD_FROM_CODE_LOOKUP = {
-        'Pension Provider' => 'WDYH_PP',
-        'Social media' => 'WDYH_SM',
-        'Citizens Advice' => 'WDYH_CA',
-        'My employer' => 'WDYH_ME',
-        'On the internet' => 'WDYH_INT',
-        'Financial Adviser' => 'WDYH_FA',
-        'Money Advice Service (MAS)' => 'WDYH_MAS',
-        'TV advert' => 'WDYH_TV',
-        'The Pensions Advisory Service (TPAS)' => 'WDYH_TPAS',
-        'Radio advert' => 'WDYH_RA',
-        'Newspaper/Magazine advert' => 'WDYH_NEWS',
-        'Friend/Word of mouth' => 'WDYH_WOM',
-        'Local Advertising' => 'WDYH_LA',
-        'Job Centre' => 'WDYH_JC',
-        'Charity' => 'WDYH_CHA'
-      }.freeze
-      HEARD_FROM_OTHER = 'WDYH_OTHER'.freeze
-
       def initialize(row, delivery_partner)
         @row = row
         @delivery_partner = delivery_partner.downcase
@@ -55,16 +36,14 @@ module Importers
         @row[9].to_s
       end
 
-      def heard_from_code
-        HEARD_FROM_CODE_LOOKUP.fetch(heard_from_raw, HEARD_FROM_OTHER)
-      end
+      alias heard_from_code heard_from_raw
 
       def location
         @row[8].to_s
       end
 
       def pension_provider
-        @row[10].to_s == '-' ? '' : @row[10].to_s
+        ''
       end
 
       def valid?

--- a/spec/features/import_smart_servey_data_spec.rb
+++ b/spec/features/import_smart_servey_data_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Importing smart survey data' do
   end
 
   def setup_mappings
-    create(:code_lookup, from: 'WDYH_WOM', to: 'Word of Mouth')
+    create(:code_lookup, from: 'Friend/Word of mouth', to: 'Friend/Word of Mouth')
   end
 
   def setup_imap_server(attachment:, partner:)
@@ -47,9 +47,9 @@ RSpec.feature 'Importing smart survey data' do
     expect(entry.given_at).to eq('2016-05-03 09:20:00')
 
     expect(entry).to have_attributes(
-      heard_from: 'Word of Mouth',
+      heard_from: 'Friend/Word of Mouth',
       heard_from_raw: 'Friend/Word of mouth',
-      pension_provider: 'L&G',
+      pension_provider: '',
       location: 'Belfast',
       delivery_partner: partner.downcase
     )


### PR DESCRIPTION
Ensures the simplified mappings are used. This includes deprecating the
`pension_provider` field in this context as it is no longer used.