### PR TITLE
Accommodate new exit poll for reporting

### DIFF
--- a/lib/importers/google/satisfaction/call_record.rb
+++ b/lib/importers/google/satisfaction/call_record.rb
@@ -3,17 +3,11 @@ module Importers
     module Satisfaction
       class CallRecord
         SATISFACTION_VALUE = {
-          'Delighted' => 4,
-          'Very pleased' => 3,
-          'Satisfied' => 2,
-          'Frustrated' => 1,
-          'Very frustrated' => 0
-        }.freeze
-
-        LOCATION_COLUMN = {
-          'cas' => 10,
-          'cita' => 10,
-          'nicab' => 7
+          'Very satisfied' => 4,
+          'Fairly satisfied' => 3,
+          'Neither satisfied nor dissatisfied' => 2,
+          'Fairly dissatisfied' => 1,
+          'Very dissatisfied' => 0
         }.freeze
 
         def initialize(cells, row_index, delivery_partner)
@@ -34,15 +28,15 @@ module Importers
         end
 
         def uid
-          "#{@delivery_partner}:#{@row_index}"
+          "#{@delivery_partner}:#{@row_index}:#{given_at.to_i}"
         end
 
         def given_at
-          Time.zone.parse(@cells[0])
+          Time.zone.parse("#{@cells[2]} 09:00")
         end
 
         def satisfaction_raw
-          @cells[2].to_s
+          @cells[3].to_s
         end
 
         def satisfaction
@@ -50,8 +44,7 @@ module Importers
         end
 
         def location
-          location_column = LOCATION_COLUMN[@delivery_partner]
-          @cells[location_column].to_s
+          @cells[1].to_s
         end
 
         def valid?

--- a/spec/cassettes/google_satisfaction_data.yml
+++ b/spec/cassettes/google_satisfaction_data.yml
@@ -119,56 +119,24 @@ http_interactions:
           "values": [
             [
               "Timestamp",
-              "Time and date of guidance session",
-              "Overall, how satisfied are you with the service you received from Pension Wise? ",
-              "What were the main things you were hoping to get from you Pension Wise appointment?",
-              "Were your expectations met?",
-              "Do you know what you're going to do next?",
-              "Any other comments",
-              "Which location are you in?",
-              "Name",
-              "Email",
-              "Phone number"
+              "Location",
+              "Date of guidance session",
+              "Thinking about your overall experience of Pension Wise, how satisfied or dissatisfied are you with the service?",
+              "Please let us know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:"
             ],
             [
               "25/05/2016 10:10:00",
-              "24/05/2016 11:00:00",
-              "Delighted",
-              "Find out which pension options might be suitable for me",
-              "Yes",
-              "Contact my pension provider",
-              "Very pleased with the advice I was given by Mr Ian Thompson",
-              "Newtownabbey"
+              "Newtownabbey",
+              "25/05/2016",
+              "Very satisfied",
+              "Very pleased with the advice I was given by Mr Ian Thompson"
             ],
             [
               "25/05/2016 10:12:00",
-              "24/05/2016 13:00:00",
-              "Delighted",
-              "To find the answer to a specific question",
-              "Yes",
-              "Contact my pension provider",
-              "",
-              "Banbridge"
-            ],
-            [
-              "25/05/2016 10:22:00",
-              "20/05/2016 14:00:00",
-              "Very pleased",
-              "Understand what I can do with my pension pot, Find out which pension options might be suitable for me",
-              "Yes",
-              "Get more information somewhere else, eg internet, newspapers, friends, family, Shop around to check if I can get a better deal from another provider",
-              "",
-              "Belfast"
-            ],
-            [
-              "27/05/2016 10:14:00",
-              "26/05/2016 10:30:00",
-              "Delighted",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "Contact my pension provider",
-              "",
-              "L'Derry City Side"
+              "Banbridge",
+              "24/05/2016",
+              "Fairly satisfied",
+              "Contact my pension provider"
             ]
           ]
         }
@@ -231,68 +199,24 @@ http_interactions:
           "values": [
             [
               "Timestamp",
-              "Time and date of guidance session",
-              "Overall, how satisfied are you with the service you received from Pension Wise? ",
-              "What were the main things you were hoping to get from you Pension Wise appointment?",
-              "Were your expectations met?",
-              "Do you know what you're going to do next?",
-              "Any other comments",
-              "Name",
-              "Email",
-              "Phone number",
-              "Which location are you in? "
+              "Location",
+              "Date of guidance session",
+              "Thinking about your overall experience of Pension Wise, how satisfied or dissatisfied are you with the service?",
+              "Please let us know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:"
             ],
             [
               "26/05/2016 09:38:17",
-              "25/05/2016 16:00:00",
-              "Delighted",
-              "Understand what I can do with my pension pot, Find out which pension options might be suitable for me",
-              "Yes",
-              "Contact my pension provider",
-              "Thank you Julie for giving me a work friendly appointment time and a cool room (not too hot) and clear information.\n\nToni O'Toole",
-              "",
-              "",
-              "",
-              "Citizens Advice Edinburgh (Administration)"
+              "Citizens Advice Edinburgh (Administration)",
+              "25/05/2016",
+              "Neither satisfied nor dissatisfied",
+              "Thank you Julie for giving me a work friendly appointment time and a cool room (not too hot) and clear information.\n\nToni O'Toole"
             ],
             [
               "26/05/2016 13:06:57",
-              "26/05/2016 11:00:00",
-              "Delighted",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "Speak to a financial advisor",
-              "",
-              "",
-              "",
-              "",
-              "Aberdeen Citizens Advice Bureau"
-            ],
-            [
-              "26/05/2016 17:08:13",
-              "26/05/2016 13:30:00",
-              "Delighted",
-              "Understand what I can do with my pension pot, Find out which pension options might be suitable for me",
-              "Yes",
-              "Contact my pension provider",
-              "",
-              "",
-              "",
-              "",
-              "Stirling District Citizens Advice Bureau Ltd"
-            ],
-            [
-              "27/05/2016 11:05:29",
-              "27/05/2016 10:00:00",
-              "Delighted",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "Contact my pension provider",
-              "",
-              "",
-              "",
-              "",
-              "Aberdeen Citizens Advice Bureau"
+              "Aberdeen Citizens Advice Bureau",
+              "26/05/2016",
+              "Very satisfied",
+              ""
             ]
           ]
         }
@@ -355,68 +279,24 @@ http_interactions:
           "values": [
             [
               "Timestamp",
-              "Time and Date of Guidance Session",
-              "Overall, how satisfied are you with the service you received from Pension Wise?",
-              "What were the main things you were hoping to get from your Pension Wise appointment?",
-              "Were your expectations met?",
-              "Do you know what you're going to do next?",
-              "Any other comments",
-              "Name",
-              "Email",
-              "Phone Number",
-              "Member"
+              "Location",
+              "Date of guidance session",
+              "Thinking about your overall experience of Pension Wise, how satisfied or dissatisfied are you with the service?",
+              "Please let us know anything that has made you particularly satisfied or dissatisfied with the Pension Wise service:"
             ],
             [
               "27/05/2016 08:43:11",
-              "25/05/2016 11:15:00",
-              "Delighted",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "Get more information somewhere else, eg: internet, newspapers, friends family",
-              "",
-              "",
-              "",
-              "",
-              "Lincoln & District"
+              "Lincoln & District",
+              "25/05/2016",
+              "Very dissatisfied",
+              "The appointment wasn't as good as I expected."
             ],
             [
               "27/05/2016 08:43:48",
-              "25/05/2016 13:30:00",
-              "Very pleased",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "I'm unsure what steps I should take next",
-              "",
-              "",
-              "",
-              "",
-              "Lincoln & District"
-            ],
-            [
-              "27/05/2016 08:59:27",
-              "26/05/2016 14:45:00",
-              "Very pleased",
-              "Understand what I can do with my pension pot",
-              "Yes",
-              "Contact my pension provider, Get more information somewhere else, eg: internet, newspapers, friends family, Shop around to check if I can get a better deal from another provider",
-              "",
-              "",
-              "",
-              "",
-              "Peterborough"
-            ],
-            [
-              "27/05/2016 09:01:56",
-              "26/05/2016 13:30:00",
-              "Delighted",
-              "Understand what I can do with my pension pot, Find out which pension options might be suitable for me, To find the answer to a specific question",
-              "Yes",
-              "Contact my pension provider",
-              "Very pleased to get confirmation of the guess I'd made about tax implications",
-              "",
-              "",
-              "",
-              "Peterborough"
+              "Peterborough",
+              "25/05/2016",
+              "Very satisfied",
+              ""
             ]
           ]
         }

--- a/spec/features/import_google_satisfaction_data_spec.rb
+++ b/spec/features/import_google_satisfaction_data_spec.rb
@@ -38,10 +38,8 @@ RSpec.feature 'Importing satisfaction data', vcr: { cassette_name: 'google_satis
   def then_google_satisfaction_data_has_been_saved_for_cas
     expect(Satisfaction.where(delivery_partner: 'cas').pluck(:uid, :given_at, :satisfaction, :location)).to eq(
       [
-        ['cas:1', Time.zone.parse('2016-05-26 09:38:17'), 4, 'Citizens Advice Edinburgh (Administration)'],
-        ['cas:2', Time.zone.parse('2016-05-26 13:06:57'), 4, 'Aberdeen Citizens Advice Bureau'],
-        ['cas:3', Time.zone.parse('2016-05-26 17:08:13'), 4, 'Stirling District Citizens Advice Bureau Ltd'],
-        ['cas:4', Time.zone.parse('2016-05-27 11:05:29'), 4, 'Aberdeen Citizens Advice Bureau']
+        ['cas:1:1464166800', Time.zone.parse('2016-05-25 09:00'), 2, 'Citizens Advice Edinburgh (Administration)'],
+        ['cas:2:1464253200', Time.zone.parse('2016-05-26 09:00'), 4, 'Aberdeen Citizens Advice Bureau']
       ]
     )
   end
@@ -49,10 +47,8 @@ RSpec.feature 'Importing satisfaction data', vcr: { cassette_name: 'google_satis
   def then_google_satisfaction_data_has_been_saved_for_cita
     expect(Satisfaction.where(delivery_partner: 'cita').pluck(:uid, :given_at, :satisfaction, :location)).to eq(
       [
-        ['cita:1', Time.zone.parse('2016-05-27 08:43:11'), 4, 'Lincoln & District'],
-        ['cita:2', Time.zone.parse('2016-05-27 08:43:48'), 3, 'Lincoln & District'],
-        ['cita:3', Time.zone.parse('2016-05-27 08:59:27'), 3, 'Peterborough'],
-        ['cita:4', Time.zone.parse('2016-05-27 09:01:56'), 4, 'Peterborough']
+        ['cita:1:1464166800', Time.zone.parse('2016-05-25 09:00'), 0, 'Lincoln & District'],
+        ['cita:2:1464166800', Time.zone.parse('2016-05-25 09:00'), 4, 'Peterborough']
       ]
     )
   end
@@ -60,10 +56,8 @@ RSpec.feature 'Importing satisfaction data', vcr: { cassette_name: 'google_satis
   def then_google_satisfaction_data_has_been_saved_for_nicab
     expect(Satisfaction.where(delivery_partner: 'nicab').pluck(:uid, :given_at, :satisfaction, :location)).to eq(
       [
-        ['nicab:1', Time.zone.parse('2016-05-25 10:10:00'), 4, 'Newtownabbey'],
-        ['nicab:2', Time.zone.parse('2016-05-25 10:12:00'), 4, 'Banbridge'],
-        ['nicab:3', Time.zone.parse('2016-05-25 10:22:00'), 3, 'Belfast'],
-        ['nicab:4', Time.zone.parse('2016-05-27 10:14:00'), 4, 'L\'Derry City Side']
+        ['nicab:1:1464166800', Time.zone.parse('2016-05-25 09:00'), 4, 'Newtownabbey'],
+        ['nicab:2:1464080400', Time.zone.parse('2016-05-24 09:00'), 3, 'Banbridge']
       ]
     )
   end


### PR DESCRIPTION
The exit polls have changed for face-to-face appointments and we need
to alter the way we process and import the google satisfaction data to
match the new shape and structure of this data.

The headline changes are:

* Keyword changes for the raw satisfaction value
* Simplified locations, raw satisfaction (unified positionally)
* Accurate appointment dates

Appointment times are fudged to `09:00` since the time portion of the
appointment is not accurately reported. Previously we were incorrectly
using the date/time from the `timestamp`. This represents the date/time
the data was entered, not the actual appointment date/time.