### PR TITLE
Parse Smart Survey email HTML part

### DIFF
--- a/config/initializers/importers.rb
+++ b/config/initializers/importers.rb
@@ -23,8 +23,7 @@ Rails.configuration.x.smart_survey.tap do |ss|
   ss.search_string = ENV.fetch('SS_SEARCH_STRING', 'SUBJECT "SmartSurvey Exported Data"')
   ss.file_name_regexp = Regexp.new(ENV.fetch('SS_FILE_NAME_REGEXP', 'RawData--.*\.csv'))
   ss.delivery_partner_regexp = Regexp.new(
-    ENV.fetch('SS_DELIVERY_PARTNER_REGEXP', '\*Report Name:\* (.*) CSV Export'),
-    Regexp::MULTILINE
+    ENV.fetch('SS_DELIVERY_PARTNER_REGEXP', %r{\<b\>Report Name\:\<\/b\> (.*) CSV Export}m)
   )
 end
 

--- a/lib/importers/smart_survey/retriever.rb
+++ b/lib/importers/smart_survey/retriever.rb
@@ -21,7 +21,7 @@ module Importers
       end
 
       def extract_delivery_partner(email)
-        match = email.body_text.match(@config.delivery_partner_regexp)
+        match = email.body_html.match(@config.delivery_partner_regexp)
         match && match[1]
       end
     end

--- a/lib/mail_retriever.rb
+++ b/lib/mail_retriever.rb
@@ -73,8 +73,8 @@ class MailRetriever
       @mail = mail
     end
 
-    def body_text
-      @mail.text_part.body.to_s
+    def body_html
+      @mail.html_part.decoded
     end
   end
 end

--- a/spec/features/import_smart_survey_data_spec.rb
+++ b/spec/features/import_smart_survey_data_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Importing smart survey data' do
       :mail_attachment,
       file: StringIO.new(attachment),
       uid: SecureRandom.uuid,
-      body_text: "Hi\n*Report Name:* #{partner} CSV Export"
+      body_html: "\n\n<b>Report Name:</b> #{partner} CSV Export"
     )
     mail_retriever = instance_double(MailRetriever, search: [mail_attachment], archive: true)
     allow(MailRetriever).to receive(:new).and_return(mail_retriever)


### PR DESCRIPTION
Smart Survey do not include the plain-text part in export emails so we
must instead parse the HTML part.