### PR TITLE
Improve sheet access

### DIFF
--- a/lib/importers/tp_satisfaction/importer.rb
+++ b/lib/importers/tp_satisfaction/importer.rb
@@ -15,7 +15,7 @@ module Importers
 
       def import
         @retriever.process_emails do |email|
-          records = @record.build(io: email.file, sheet_name: @config.sheet_name)
+          records = @record.build(io: email.file)
           @saver.new(records: records).save
         end
       end

--- a/lib/importers/tp_satisfaction/record.rb
+++ b/lib/importers/tp_satisfaction/record.rb
@@ -64,7 +64,7 @@ module Importers
         @cells['Date']&.value.to_s
       end
 
-      def self.build(io:, sheet_name:)
+      def self.build(io:) # rubocop:disable AbcSize, MethodLength
         begin
           workbook = RubyXL::Parser.parse_buffer(io)
         rescue => e
@@ -72,8 +72,10 @@ module Importers
           return nil
         end
 
-        header_row = workbook[sheet_name][0].cells.map(&:value).compact
-        workbook[sheet_name].map do |row|
+        Rails.logger.info("Found sheets: #{workbook.worksheets.map(&:sheet_name).join(', ')}")
+
+        header_row = workbook[0][0].cells.map(&:value).compact
+        workbook[0].map do |row|
           new(Hash[header_row.zip(row.cells[0..3])])
         end
       end


### PR DESCRIPTION
Try and access the first sheet more reliably since TP sometimes change
the sheet name. Accessing by ordinal should be safer since there is only
ever one sheet provided.

We log the found sheet names just for instrumentation purposes.