### PR TITLE
Access sheets ordinally

### DIFF
--- a/lib/importers/tp/call_record.rb
+++ b/lib/importers/tp/call_record.rb
@@ -101,15 +101,15 @@ module Importers
         end
       end
 
-      def self.build(io:, sheet_name:)
+      def self.build(io:)
         begin
           workbook = RubyXL::Parser.parse_buffer(io)
         rescue => e
           Bugsnag.notify(e)
           return nil
         end
-        header_row = workbook[sheet_name][0].cells.to_a.map(&:value)
-        workbook[sheet_name].map do |row|
+        header_row = workbook[0][0].cells.to_a.map(&:value)
+        workbook[0].map do |row|
           new(Hash[header_row.zip(row.cells.to_a)])
         end
       end

--- a/lib/importers/tp/importer.rb
+++ b/lib/importers/tp/importer.rb
@@ -10,7 +10,7 @@ module Importers
 
       def import
         @retriever.process_emails do |email|
-          calls = @call_record.build(io: email.file, sheet_name: @config.sheet_name)
+          calls = @call_record.build(io: email.file)
           calls && @saver.new(calls: calls).save
         end
       end


### PR DESCRIPTION
This means we no longer rely on TP naming to stay consistent.