### PR TITLE
Configure the office 365 IMAP server

### DIFF
--- a/lib/mail_retriever.rb
+++ b/lib/mail_retriever.rb
@@ -25,7 +25,7 @@ require 'mail'
 
 class MailRetriever
   DEFAULT_CONFIG = {
-    address: 'imap.googlemail.com',
+    address: 'outlook.office365.com',
     port: 993,
     enable_ssl: true,
     user_name: nil,

--- a/spec/lib/mail_retriver_spec.rb
+++ b/spec/lib/mail_retriver_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MailRetriever do
 
   it 'initializes the IMAP object' do
     expect(Mail::IMAP).to receive(:new).with(
-      address: 'imap.googlemail.com',
+      address: 'outlook.office365.com',
       port: 993,
       enable_ssl: true,
       password: 'password',


### PR DESCRIPTION
This default has changed due to the migration away from google.