### PR TITLE
Parse the subject case-insensitive

### DIFF
--- a/lib/importers/cita_satisfaction/record.rb
+++ b/lib/importers/cita_satisfaction/record.rb
@@ -80,7 +80,7 @@ module Importers
       end
 
       def self.parse_subject(subject)
-        if matches = subject.match(/\A(.*) Telephony Exit Poll.*\Z/) # rubocop:disable GuardClause
+        if matches = subject.match(/\A(.*) Telephony Exit Poll.*\Z/i) # rubocop:disable GuardClause
           matches[1].underscore.tr(' ', '_')
         else
           raise "Could not parse subject: #{subject}"


### PR DESCRIPTION
Some of the emails are mixed case and the 'Exit Poll' part is discarded
anyway so there is no need to be so specific.